### PR TITLE
Campfire has enabled SSL by default

### DIFF
--- a/docs/campfire
+++ b/docs/campfire
@@ -5,7 +5,7 @@ Install Notes
 -------------
 
   1. subdomain is your campfire subdomain
-	(ie 'your-subdomain' if you visit 'http://your-subdomain.campfirenow.com')
+	(ie 'your-subdomain' if you visit 'https://your-subdomain.campfirenow.com')
 
   2. room is the actual room name, not the id
 
@@ -20,7 +20,6 @@ data
   - subdomain
   - token
   - room
-  - ssl
   - play_sound
 
 payload

--- a/services/campfire.rb
+++ b/services/campfire.rb
@@ -9,7 +9,7 @@ service :campfire do |data, payload|
   compare_url = payload['compare']
   commits.reject! { |commit| commit['message'].to_s.strip == '' }
   next if commits.empty?
-  campfire   = Tinder::Campfire.new(data['subdomain'], :ssl => data['ssl'].to_i == 1)
+  campfire   = Tinder::Campfire.new(data['subdomain'], :ssl => true)
   play_sound = data['play_sound'].to_i == 1
 
   if !campfire.login(data['token'], 'X')


### PR DESCRIPTION
This change makes SSL get used by default in the service hook for Campfire. 
