### PR TITLE
Added IRC full authentication support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@ Thanks to the following people for making this possible
 - Nick Gerakines
 - Noah (ngage)
 - Paul Stamatiou
+- Sam Pierson
 - Sanko Robinson
 - Sean O'Brien
 - Tekkub Stoutwrithe

--- a/docs/irc
+++ b/docs/irc
@@ -7,12 +7,13 @@ Install Notes
   1. server (ie. irc.freenode.net)
   2. port is normally 6667 / 9999 for ssl
   3. the room field can support multiple rooms (comma separated)
-  4. the password field is for the server password
-  5. room passwords can be specified for each room like this:
+  4  username if your server requires real authentication
+  5. the password field is for the server password
+  6. room passwords can be specified for each room like this:
        room_name::password
-  6. prefixing '#' to the room field is optional
-  7. nick is not required, if provided the IRCBot will use that nick
-  8. Enable long_url so that compare/commit url's are not passed 
+  7. prefixing '#' to the room field is optional
+  8. nick is not required, if provided the IRCBot will use that nick
+  9. Enable long_url so that compare/commit url's are not passed
      through bit.ly.
 
 
@@ -23,6 +24,7 @@ data
   - server
   - port
   - room
+  - username
   - password
   - ssl
   - nick

--- a/services/irc.rb
+++ b/services/irc.rb
@@ -6,6 +6,7 @@ service :irc do |data, payload|
     branch     = payload['ref_name']
     rooms      = data['room'].gsub(",", " ").split(" ").map{|room| room[0].chr == '#' ? room : "##{room}"}
     botname    = data['nick'].to_s.empty? ? "GitHub#{rand(200)}" : data['nick']
+    username   = data['username'].to_s.empty? ? botname : data['username']
     socket     = nil
 
     socket = TCPSocket.open(data['server'], data['port'])
@@ -47,9 +48,9 @@ service :irc do |data, payload|
       irc = socket
     end
 
+    irc.puts "USER #{username} 8 * :GitHub IRCBot"
     irc.puts "PASS #{data['password']}" if data['password'] && !data['password'].empty?
     irc.puts "NICK #{botname}"
-    irc.puts "USER #{botname} 8 * :GitHub IRCBot"
 
     loop do
       case irc.gets


### PR DESCRIPTION
Many IRC servers require a real username/password combo, e.g. our corporate IRC server which is integrated with LDAP. This fix adds a new data field "username" to the IRC service, which will be used for authentication if present. Fallback is the nickname, as before.
