### PR TITLE
Add page/action to payload in mantis_rb hook.

### DIFF
--- a/services/mantis_bt.rb
+++ b/services/mantis_bt.rb
@@ -1,7 +1,10 @@
 service :mantis_bt do |data, payload|
   begin
     base_url = data['url'].chomp('/')
-    full_url = "#{base_url}/plugin.php?page=Source/checkin"
+    full_url = "#{base_url}/plugin.php"
+
+    #add page/action to payload
+    payload['page'] = 'Source/checkin'
 
     Net::HTTP.post_form(URI.parse(full_url), payload)
 


### PR DESCRIPTION
The hook used to specify the page/action in the Mantis website as url-encoded parameters, which does not work. What should work however is to add them to the payload of the POST request instead.
This change assumes that the payload does not contain a 'page' key. I hope this is justified?
