### PR TITLE
Reverting "Added username support to IRC"

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,7 +25,6 @@ Thanks to the following people for making this possible
 - Nick Gerakines
 - Noah (ngage)
 - Paul Stamatiou
-- Sam Pierson
 - Sanko Robinson
 - Sean O'Brien
 - Tekkub Stoutwrithe

--- a/docs/irc
+++ b/docs/irc
@@ -7,13 +7,12 @@ Install Notes
   1. server (ie. irc.freenode.net)
   2. port is normally 6667 / 9999 for ssl
   3. the room field can support multiple rooms (comma separated)
-  4  username if your server requires real authentication
-  5. the password field is for the server password
-  6. room passwords can be specified for each room like this:
+  4. the password field is for the server password
+  5. room passwords can be specified for each room like this:
        room_name::password
-  7. prefixing '#' to the room field is optional
-  8. nick is not required, if provided the IRCBot will use that nick
-  9. Enable long_url so that compare/commit url's are not passed
+  6. prefixing '#' to the room field is optional
+  7. nick is not required, if provided the IRCBot will use that nick
+  8. Enable long_url so that compare/commit url's are not passed 
      through bit.ly.
 
 
@@ -24,7 +23,6 @@ data
   - server
   - port
   - room
-  - username
   - password
   - ssl
   - nick

--- a/services/irc.rb
+++ b/services/irc.rb
@@ -6,7 +6,6 @@ service :irc do |data, payload|
     branch     = payload['ref_name']
     rooms      = data['room'].gsub(",", " ").split(" ").map{|room| room[0].chr == '#' ? room : "##{room}"}
     botname    = data['nick'].to_s.empty? ? "GitHub#{rand(200)}" : data['nick']
-    username   = data['username'].to_s.empty? ? botname : data['username']
     socket     = nil
 
     socket = TCPSocket.open(data['server'], data['port'])
@@ -48,9 +47,9 @@ service :irc do |data, payload|
       irc = socket
     end
 
-    irc.puts "USER #{username} 8 * :GitHub IRCBot"
     irc.puts "PASS #{data['password']}" if data['password'] && !data['password'].empty?
     irc.puts "NICK #{botname}"
+    irc.puts "USER #{botname} 8 * :GitHub IRCBot"
 
     loop do
       case irc.gets


### PR DESCRIPTION
It turns out that this breaks compliance with RFC1459.  Thanks to aymerick for bringing this to my attention.  Apologies for the disruption.  I need to go take a long hard look at our IRC server.  Seems like it's LDAP integration might be questionable.
