### PR TITLE
Adding TeamCity service

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,3 +48,4 @@ Thanks to the following people for making this possible
 - Matias Korhonen
 - Stian Grytøyr
 - Nils Adermann
+- Brian R. Jackson

--- a/docs/github_payload
+++ b/docs/github_payload
@@ -2,7 +2,10 @@
 
 {
   "data" => {
-	  "subscribers" => "" #CSV list
+	  "base_url" => "http://teamcity.example.com/",
+	  "build_type_id" => "bt123",
+	  "username" => "DOMAIN\\user",
+	  "password" => "MyP@ssw0rD"
   },
 
   "payload" => {

--- a/docs/teamcity
+++ b/docs/teamcity
@@ -1,0 +1,31 @@
+TeamCity
+=======
+
+TeamCity is a continuous integration server that automates the building and testing of your software.
+The github TeamCity service can be used to trigger builds after code has been pushed to your git repository.
+
+Install Notes
+-------------
+
+  1.  Your TeamCity server must be accessible from the internet.
+
+  2.  "base_url" is the URL to your TeamCity server
+      Example: https://teamcity.example.com/ or http://teamcity.example.com/teamcity/
+
+  3.  "build_type_id" is the identifier of the build configuration you want to trigger
+      Example: "bt123", which can be found in URL of the build configuration page ("...viewType.html?buildTypeId=bt123&...")
+
+  4.  "username" and "password" - username and password of a TeamCity user that can
+      trigger a manual build of the TeamCity build configuration defined in "build_type_id"
+
+Developer Notes
+---------------
+
+data
+  - base_url
+  - build_type_id
+  - username
+  - password
+
+payload
+  - refer to docs/github_payload

--- a/services/teamcity.rb
+++ b/services/teamcity.rb
@@ -1,0 +1,42 @@
+module TeamCity
+  class Remote
+
+    def initialize(data = {})
+      @base_url, @build_type_id, @username, @password = data['base_url'], data['build_type_id'], data['username'], data['password']
+      instance_variables.each{|var| raise GitHub::ServiceConfigurationError.new("Missing configuration: #{var}") if instance_variable_get(var).to_s.empty? }
+      @uri = URI.parse(@base_url.gsub(/\/$/, ''))
+      @conn = Net::HTTP.new(@uri.host, @uri.port)
+      @conn.use_ssl = @uri.scheme.eql?("https")
+      @conn.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
+    
+    def trigger_build
+      @conn.start do |http|
+        req = Net::HTTP::Get.new('/httpAuth/action.html?add2Queue=' + CGI.escape(@build_type_id))
+        req.basic_auth @username, @password
+        resp = http.request(req)
+        if resp
+          # TeamCity REST API never returns a body
+          # but at least raise an HTTP error if response.code is not 2xx
+          resp.value
+        end
+      end 
+    end
+    
+  end
+end
+
+service :teamcity do |data, payload|
+  begin
+    TeamCity::Remote.new(data).trigger_build
+  rescue SocketError => e
+    raise GitHub::ServiceConfigurationError.new("Invalid TeamCity host name") if e.to_s =~ /getaddrinfo: Name or service not known/
+    raise
+  rescue => e
+    case e.to_s
+      when /\((?:403|401|422)\)/ then raise GitHub::ServiceConfigurationError, "Invalid credentials"
+      when /\((?:404|301|302)\)/ then raise GitHub::ServiceConfigurationError, "Invalid TeamCity URL"
+      else raise
+    end
+  end
+end


### PR DESCRIPTION
I've added a github-services service that can trigger TeamCity builds.  TeamCity is a continuous integration server by JetBrains.

http://jetbrains.com/teamcity

I've tested my service with both a 5.x and 6.x installation of TeamCity.
