### PR TITLE
Twitter service fails for long commit messages

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -50,3 +50,4 @@ Thanks to the following people for making this possible
 - Nils Adermann
 - Brian R. Jackson
 - Eric Pierce
+- Adam Duke

--- a/services/twitter.rb
+++ b/services/twitter.rb
@@ -40,11 +40,13 @@ service :twitter do |data, payload|
   if data['digest'] == '1'
     commit = payload['commits'][-1]
     tiny_url = shorten_url(payload['repository']['url'] + '/commits/' + payload['ref_name'])
-    statuses << "[#{repository}] #{tiny_url} #{commit['author']['name']} - #{payload['commits'].length} commits"
+    status = "[#{repository}] #{tiny_url} #{commit['author']['name']} - #{payload['commits'].length} commits"
+    status.length >= 140 ? statuses << status[0..136] + '...' : statuses << status
   else
     payload['commits'].each do |commit|
       tiny_url = shorten_url(commit['url'])
-      statuses << "[#{repository}] #{tiny_url} #{commit['author']['name']} - #{commit['message']}"
+      status = "[#{repository}] #{tiny_url} #{commit['author']['name']} - #{commit['message']}"
+      status.length >= 140 ? statuses << status[0..136] + '...' : statuses << status
     end
   end
 


### PR DESCRIPTION
It's possible that the status update, built in the twitter service, can be over 140 characters, which is Twitter's limit. Running github-services locally, it seems like this silently fails. The twitter service should truncate the status update at 137 characters and add an ellipsis to indicate that there is more content.
