### PR TITLE
Adding support for HTTPS to the trac service-hook

### DIFF
--- a/services/trac.rb
+++ b/services/trac.rb
@@ -3,8 +3,15 @@ service :trac do |data, payload|
     #The data['url'] may contain a subdirectory, so this fails
     #url = URI.join(data['url'], '/github/', data['token'])
     url_value = data['url'].chomp('/')
-    url = "#{url_value}/github/#{data['token']}"
-    Net::HTTP.post_form(URI.parse(url), "payload" => payload.to_json)
+    url = URI.parse("#{url_value}/github/#{data['token']}")
+    req = Net::HTTP::Post.new(url.path)
+    req.set_form_data({"payload" => payload.to_json})
+    if url.user
+      req.basic_auth url.user, url.password
+    end
+    http_session = Net::HTTP.new(url.host, url.port)
+    http_session.use_ssl = true if url.port == 443
+    http_session.start {|http| http.request(req)}
   rescue Net::HTTPBadResponse => boom
     raise GitHub::ServiceConfigurationError, "Invalid configuration"
   rescue Errno::ECONNREFUSED => boom


### PR DESCRIPTION
I'm not too familiar with ruby but this should replicate the functionality available in the package at the moment for simple HTTP requests except make it available to HTTPS requests.
