### PR TITLE
HipChat service changes

### DIFF
--- a/docs/hipchat
+++ b/docs/hipchat
@@ -4,15 +4,17 @@ HipChat
 Install Notes
 -------------
 
-  1. Auth token - one of your group's API tokens. See: http://www.hipchat.com/docs/api/auth
-  2. Room - the full name of the room to send the message to. The room's room_id will also work.
+  1. Auth token - One of your group's API tokens. See: http://www.hipchat.com/docs/api/auth
+  2. Room - The full name of the room to send the message to. The room's room_id will also work.
+  3. Notify - Whether or not to notify room members.
 
 Developer Notes
 ---------------
 
 data
  - auth_token
- - room_id
+ - room
+ - notify (boolean)
 
 payload
   - refer to docs/github_payload

--- a/services/hipchat.rb
+++ b/services/hipchat.rb
@@ -1,15 +1,27 @@
 service :hip_chat do |data, payload|
   # make sure we have what we need
-  throw :halt, [400, "Missing auth_token"] if data['auth_token'].to_s == ''
-  throw :halt, [400, "Missing room"] if data['room'].to_s == ''
+  throw :halt, [400, "Missing 'auth_token'"] if data['auth_token'].to_s == ''
+  throw :halt, [400, "Missing 'room'"] if data['room'].to_s == ''
 
-  # send it
-  url = URI.parse("http://api.hipchat.com/v1/rooms/message_github")
-  Net::HTTP.post_form(url, {
+  req = Net::HTTP::Post.new("/v1/webhooks/github")
+  req.set_form_data({
     :auth_token => data['auth_token'],
     :room_id => data['room'],
     :payload => JSON.generate(payload),
+    :notify => data['notify'] ? 1 : 0
   })
+  req["Content-Type"] = 'application/x-www-form-urlencoded'
+
+  http = Net::HTTP.new("api.hipchat.com", 443)
+  http.use_ssl = true
+  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+  begin
+    http.start do |connection|
+      connection.request(req)
+    end
+  rescue Net::HTTPBadResponse
+    raise GitHub::ServiceConfigurationError, "Invalid configuration"
+  end
 
   # Sinatra expects a string return
   "Great success!"


### PR DESCRIPTION
Change #1 - Add support for a "notify" setting which determines whether or not room participants will be notified (sound, growl popup, etc) for the message. Expect this to be a checkbox in the GitHub UI.

Change #2 - Use HTTPS.

Thanks!
