### PR TITLE
Fogbugz - Use "case[s]" as a keyword to associate a commit with a bug

### DIFF
--- a/services/fog_bugz.rb
+++ b/services/fog_bugz.rb
@@ -12,7 +12,8 @@ service :fog_bugz do |data, payload|
     # look for a bug id in each line of the commit message
     bug_list = []
     message.split("\n").each do |line|
-      if (line =~ /\s*Bug[zs]*\s*IDs*\s*[#:; ]+((\d+[ ,:;#]*)+)/i)
+      # match variants of bugids or cases
+      if (line =~ /\s*(?:Bug[zs]*\s*IDs*\s*|Case[s]*)[#:; ]+((\d+[ ,:;#]*)+)/i)
         bug_list << $1.to_i
       end
     end


### PR DESCRIPTION
In addition to variants of "bugid", I've added support for variants of "case".  This makes things more consistent with now cases are auto-linked from within fogbugz.
