### PR TITLE
Update Jaconda service to use Jaconda API v2

### DIFF
--- a/docs/jaconda
+++ b/docs/jaconda
@@ -4,16 +4,21 @@ Jaconda
 Install Notes
 -------------
 
-  1. Room ID is the numerical ID of your room, it can be found on the Room Integration page
-  2. API token is also displayed on the Room Integration page too
-  3. if Digest is checked, all commits will be compressed in one message
+Using the following url as an example:
+https://bigbang.jaconda.im/rooms/galaxo
+
+  1. Subdomain is bigbang
+  2. Room ID is galaxo
+  3. Room token can be found on the Room Integration page
+  4. if Digest is checked, all commits will be compressed in one message
 
 Developer Notes
 ---------------
 
 data
+  - subdomain
   - room_id
-  - api_token
+  - room_token
   - digest (boolean)
 
 payload

--- a/services/jaconda.rb
+++ b/services/jaconda.rb
@@ -1,46 +1,23 @@
 service :jaconda do |data, payload|
-  throw(:halt, 400) if data['api_token'].to_s == '' || data['room_id'].to_s == ''
+  throw :halt, [400, "Missing 'subdomain'"] if data['subdomain'].to_s == ''
+  throw :halt, [400, "Missing 'room_id'"] if data['room_id'].to_s == ''
+  throw :halt, [400, "Missing 'room_token'"] if data['room_token'].to_s == ''
 
-  repository = CGI.escapeHTML(payload['repository']['name'])
-  branch = CGI.escapeHTML(payload['ref_name'])
-  commits = payload['commits']
-  api_token = data['api_token']
-  room_id = data['room_id']
-  url = URI.parse("https://#{api_token.strip}:X@jaconda.im/api/rooms/#{room_id}/messages.json")
+  url = URI.parse("https://#{data['subdomain']}.jaconda.im/api/v2/rooms/#{data['room_id']}/notify/github.json")
+  req = Net::HTTP::Post.new(url.path)
+  req.set_form_data({
+    :payload => JSON.generate(payload),
+    :digest => data['digest']
+  })
+  req.basic_auth data['room_token'], "x"
+  http = Net::HTTP.new(url.host, url.port)
+  http.use_ssl = true
+  res = nil
+  http.start { |http| res = http.request(req) }
 
-  before, after = payload['before'][0..6], payload['after'][0..6]
-  compare_url = payload['repository']['url'] + "/compare/#{before}...#{after}"
-
-  if data['digest'].to_i == 1 && commits.size > 1
-    commit = commits.first
-    message = "<i>Commit <a href='#{commit["url"]}'>#{commit["id"][0..6]}</a> on #{repository}/#{branch} by #{CGI.escapeHTML(commit["author"]["name"])}</i><br /><br />"
-    message += CGI.escapeHTML(commit["message"])
-    message += "<br /><br /><i>(+#{commits.size - 1} <a href='#{compare_url}'>more commits</a>)</i>"
-
-    req = Net::HTTP::Post.new(url.path)
-    req.set_form_data(:text => message)
-    req.basic_auth url.user, url.password
-    http = Net::HTTP.new(url.host, url.port)
-    http.use_ssl = true
-    res = nil
-    http.start { |http| res = http.request(req) }
-
-    throw(:halt, [res.code.to_i, res.body.to_s]) unless res.is_a?(Net::HTTPSuccess)
+  if res.is_a?(Net::HTTPSuccess)
+    true
   else
-    commits.each do |commit|
-      message = "<i>Commit <a href='#{commit["url"]}'>#{commit["id"][0..6]}</a> on #{repository}/#{branch} by #{CGI.escapeHTML(commit["author"]["name"])}</i><br /><br />"
-      message += CGI.escapeHTML(commit["message"])
-
-      req = Net::HTTP::Post.new(url.path)
-      req.set_form_data(:text => message)
-      req.basic_auth url.user, url.password
-      http = Net::HTTP.new(url.host, url.port)
-      http.use_ssl = true
-      res = nil
-      http.start { |http| res = http.request(req) }
-
-      throw(:halt, [res.code.to_i, res.body.to_s]) unless res.is_a?(Net::HTTPSuccess)
-    end
+    throw :halt, [res.code.to_i, res.body.to_s]
   end
-  true
 end


### PR DESCRIPTION
Hi,

We've updated Github integration to use new API which introduces new fields and new tokens. Is there a way to make the transition less painful for our users?
It would be cool if they could just continue to use their integrations without changing parameters in all repositories. 

If you could provide us with Room IDs of all Jaconda integrations at Github we could generate updated list of parameters for you. Is that possible?
