### PR TITLE
New parameter “url” for “prowl” service

### DIFF
--- a/docs/prowl
+++ b/docs/prowl
@@ -3,12 +3,12 @@ Prowl
 
 Prowl is an iPhone App+Web Service for arbitrary Push Notifications. After installing the app and registering the device, you receive an API key and can send notifications from your computer via Growl (with the Prowl GrowlStyle installed) or from any server with very little work (at least as far as the Push submission is concerned).
 
-To get started, create a user account for Prowl at http://prowl.weks.net/.
+To get started, create a user account for Prowl at https://www.prowlapp.com/.
 
 Install Notes
 -------------
 
-1. apikey is your API key supplied from the Prowl website at https://prowl.weks.net/settings.php
+1. Create a new API key for GitHub at the Prowl website https://www.prowlapp.com/api_settings.php.
 
 Developer Notes
 ---------------

--- a/services/prowl.rb
+++ b/services/prowl.rb
@@ -1,5 +1,5 @@
 service :prowl do |data, payload|
-  url = URI.parse('https://prowl.weks.net/publicapi/add')
+  url = URI.parse('https://api.prowlapp.com/publicapi/add')
   repository = payload['repository']['url'].split("/")
   event = repository[-2], "/", repository[-1]
   application = "GitHub"
@@ -9,7 +9,7 @@ Latest Commit by #{payload['commits'][-1]['author']['name']}
 #{payload['commits'][-1]['id'][0..7]} #{payload['commits'][-1]['message']}"
 
   req = Net::HTTP::Post.new(url.path)
-  req.set_form_data('apikey' => data['apikey'], 'application' => application, 'event' => event, 'description' => description)
+  req.set_form_data('apikey' => data['apikey'], 'application' => application, 'event' => event, 'description' => description, 'url' => payload['compare'])
 
   http = Net::HTTP.new(url.host, url.port)
   http.use_ssl = true if url.port == 443 || url.instance_of?(URI::HTTPS)


### PR DESCRIPTION
Prowl recently added an `url` parameter to the `add` method which makes it possible to have the notification launch a URL.

Also, they changed their host name from prowl.weks.net to [www.prowlapp.com]().

I made the `url` parameter point to the `compare` view, which I deemed the most reasonable thing to do since it’s applicable to all pushed commits.
