### PR TITLE
Improve the Email service hook in 3 distinct ways

### DIFF
--- a/services/email.rb
+++ b/services/email.rb
@@ -65,6 +65,7 @@ EOH
     message = TMail::Mail.new
     message.set_content_type('text', 'plain', {:charset => 'UTF-8'})
     message.from = "#{commit['author']['name']} <#{commit['author']['email']}>" if data['send_from_author']
+    message.reply_to = "#{commit['author']['name']} <#{commit['author']['email']}>"
     message.to      = data['address']
     message.subject = "[#{name_with_owner}] #{first_commit_sha}: #{first_commit_title}"
     message.body    = body


### PR DESCRIPTION
The following changes have been made and can be merged independently:
- add a Reply-To header using the commit author
- optionally, originate the email from the commit author, so it looks nicer in an email-client / mailing-list archive
- optionally, add an Approved header with a secret to automatically approve the mail in a (read-only/moderated) mailinglist

PS Go easy on me, I still need to learn to branch using github...
