### PR TITLE
Small refinement to the e-mail hook

### DIFF
--- a/services/email.rb
+++ b/services/email.rb
@@ -66,7 +66,7 @@ EOH
     message = TMail::Mail.new
     message.set_content_type('text', 'plain', {:charset => 'UTF-8'})
     message.from = "#{commit['author']['name']} <#{commit['author']['email']}>" if data['send_from_author']
-    message.reply_to = "#{commit['author']['name']} <#{commit['author']['email']}>"
+    message.reply_to = "#{commit['author']['name']} <#{commit['author']['email']}>" if data['send_from_author']
     message.to      = data['address']
     message.subject = "[#{name_with_owner}] #{first_commit_sha}: #{first_commit_title}"
     message.body    = body


### PR DESCRIPTION
Only re-write Reply-To if send_from_author is enabled. The reason why
this is necessary is because some insufficiently clever mailing list
programs (such as mailman) get confused with conflicting From: and
Reply-To: and set From: to Reply-To: in the end, which is not what we
want them to by default.
