### PR TITLE
CIA specify project name

### DIFF
--- a/services/cia.rb
+++ b/services/cia.rb
@@ -39,7 +39,7 @@ end
 service :cia do |data, payload|
   server = XMLRPC::Client.new2("http://cia.navi.cx")
 
-  repository = payload['repository']['name']
+  repository = data['name'] || payload['repository']['name']
   branch     = payload['ref_name']
   commits    = payload['commits']
 


### PR DESCRIPTION
Needs a text field to put the eventual project name to pass to CIA.

Also add a Long URL checkbox, it's used in build_cia_commit but it's not in the front end.

Thanks.
