### PR TITLE
Allow posting to specific yammer group.

### DIFF
--- a/services/yammer.rb
+++ b/services/yammer.rb
@@ -22,6 +22,8 @@ service :yammer do |data, payload|
                                  :secret => data['access_secret']})
 
   statuses.each do |status|
-    yammer.message(:post, :body => status)
+    params = { :body => status }
+    params['group_id'] = data['group_id'] if data['group_id']
+    yammer.message(:post, params)
   end
 end


### PR DESCRIPTION
Yammer doesn't allow users to ignore specific users who post to the
toplevel company feed.  While you don't see these in the "My Feed"
stream, these messages do show up in the daily digest emails sent to
anyone who subscribes.

By containing this to a specific group, users can decide to watch the
project-specific tags, the group, or the integration user.  If a user
is not interested in development at all, this prevents the user from
being required to see it every day.

This change will need a new optional input field `group_id` to specify the ID number of the group to post to.  I've tested this interactively with and without a group identifier as well as with an incorrect one, though it's not clear to me where automated unit tests should be introduced.
