### PR TITLE
add no_colors option to irc service

### DIFF
--- a/docs/irc
+++ b/docs/irc
@@ -4,19 +4,21 @@ IRC
 Install Notes
 -------------
 
-1. `server` (ie. irc.freenode.net)
-2. `port` is normally 6667 / 9999 for ssl
-3. the `room` field can support multiple rooms (comma separated)
-4. the `password` field is for the server password
-5. room passwords can be specified for each room like this:
-       room_name::password
-6. prefixing '#' to the room field is optional
-7. `nick` is not required.  If provided, the IRCBot will use that
-   nick.
-8. Enable `long_url` so that compare/commit url's are not passed
-   through bit.ly.
-9. Enable `message_without_join' to keep the GitHub IRC bot from
-   joining and immediately leaving the channel for each push.
+1.  `server` (ie. irc.freenode.net)
+2.  `port` is normally 6667 / 9999 for ssl
+3.  the `room` field can support multiple rooms (comma separated)
+4.  the `password` field is for the server password
+5.  room passwords can be specified for each room like this:
+        room_name::password
+6.  prefixing '#' to the room field is optional
+7.  `nick` is not required.  If provided, the IRCBot will use that
+    nick.
+8.  Enable `long_url` so that compare/commit url's are not passed
+    through bit.ly.
+9.  Enable `message_without_join' to keep the GitHub IRC bot from
+    joining and immediately leaving the channel for each push.
+10. Enable `no_colors` to disable colors in the messages sent by the
+    Github IRC bot.
 
 
 Developer Notes
@@ -31,6 +33,7 @@ data
   - nick
   - long_url
   - message_without_join
+  - no_colors
 
 payload
   - refer to docs/github_payload

--- a/services/irc.rb
+++ b/services/irc.rb
@@ -18,16 +18,26 @@ service :irc do |data, payload|
         sha1   = commit['id']
         files  = Array(commit['modified'])
         dirs   = files.map { |file| File.dirname(file) }.uniq
-        "\002#{repository}:\002 \00307#{branch}\003 \00303#{author}\003 * " +
-        "\002#{sha1[0..6]}\002 (#{files.size} files in #{dirs.size} dirs): #{short}"
+        if data['no_colors'].to_i == 1
+            "#{repository}: #{branch} #{author} * " +
+            "#{sha1[0..6]} (#{files.size} files in #{dirs.size} dirs): #{short}"
+        else
+            "\002#{repository}:\002 \00307#{branch}\003 \00303#{author}\003 * " +
+            "\002#{sha1[0..6]}\002 (#{files.size} files in #{dirs.size} dirs): #{short}"
+        end
       end
 
     if messages.size > 1
       before, after = payload['before'][0..6], payload['after'][0..6]
       compare_url   = payload['repository']['url'] + "/compare/#{before}...#{after}"
       tiny_url      = data['long_url'].to_i == 1 ? compare_url : shorten_url(compare_url)
-      summary       = "\002#{repository}:\002 \00307#{branch}\003 commits " +
-                "\002#{before}\002...\002#{after}\002 - #{tiny_url}"
+      if data['no_colors'].to_i == 1
+          summary = "#{repository}: #{branch} commits " +
+                    "#{before}...#{after} - #{tiny_url}"
+      else
+          summary = "\002#{repository}:\002 \00307#{branch}\003 commits " +
+                    "\002#{before}\002...\002#{after}\002 - #{tiny_url}"
+      end
       messages << summary
     else
       commit   = payload['commits'][0]


### PR DESCRIPTION
Some channels can have the 'c' mode set to rejects any line containing color codes. In that case, the github messages are rejected.

This patch adds a "no_colors" option to remove colors from the messages the github bot sends.

I've tested it against ircd-hybrid.
