### PR TITLE
CIA: specify the branch, possibly with a template.

### DIFF
--- a/docs/cia
+++ b/docs/cia
@@ -14,6 +14,7 @@ data
   - no_spam
   - project - Optional project name, defaults to the Repository name.
   - address - Optional CIA address, defaults to http://cia.vc
+  - branch - Optional branch template, use %s to include the real branch name
 
 payload
   - refer to docs/github_payload

--- a/services/cia.rb
+++ b/services/cia.rb
@@ -45,12 +45,19 @@ service :cia do |data, payload|
     end)
 
   repository =
-    if !(name = data['project']).to_s.empty?
+    if !(name = data['project'].to_s).empty?
       name
     else
       payload['repository']['name']
     end
-  branch  = payload['ref_name']
+
+  branch =
+    if (!branch = data['branch'].to_s).empty?
+      branch.to_s % payload['ref_name']
+    else
+      payload['ref_name']
+    end
+
   commits = payload['commits']
 
   if commits.size > 5


### PR DESCRIPTION
I know this sounds weird, but I really need it.

In this case I have 3 repositories that are directed to the same project on CIA, but all of them have master as branch, so with this change you can specify a branch with "branch name" or "something %s" and %s will be replaced with the real branch name.

Needs a new field called branch :)

Oh also, a "Long URL" checkbox is still missing :)

Thank you for the time.
