### PR TITLE
commit id moved to the end at the FriendFeed comment 

### DIFF
--- a/services/friend_feed.rb
+++ b/services/friend_feed.rb
@@ -4,7 +4,7 @@ service :friend_feed do |data, payload|
 
   payload['commits'].each do |commit|
     title = "#{commit['author']['name']} just committed a change to #{repository} on GitHub"
-    comment = "#{commit['id']} - #{commit['message']}"
+    comment = "#{commit['message']} (#{commit['id']})"
 
     req = Net::HTTP::Post.new(friendfeed_url.path)
     req.basic_auth(data['nickname'], data['remotekey'])


### PR DESCRIPTION
Commit id doesn't look good in the first part of post comment, moved to end and surrounded with braces.
