### PR TITLE
script/deliver_payload did not work

### DIFF
--- a/script/deliver_payload
+++ b/script/deliver_payload
@@ -16,4 +16,4 @@ data_json = JSON.generate(hash["data"])
 payload_json = JSON.generate(hash["payload"])
 
 File.open( "docs/payload_data", 'w' ) { |f| f.write( "data=#{data_json}&payload=#{payload_json}" ) }
-exec "curl --data-binary @docs/payload_data http://localhost:8080/#{ARGV[0]}/"
+exec "curl --data-binary @docs/payload_data http://localhost:8080/#{ARGV[0]}/commit"


### PR DESCRIPTION
script/deliver_payload did not work because sinatra now expects an 'event' added to the URL. I couldn't find any documentation of this, so I just modified the curl call to add 'commit' as event. The code now works.
