### PR TITLE
IRC welcome commands

### DIFF
--- a/services/irc.rb
+++ b/services/irc.rb
@@ -68,18 +68,16 @@ class Service::IRC < Service
   def irc
     @irc ||= begin
       socket = TCPSocket.open(data['server'], data['port'])
-    end
-
-    if data['ssl'].to_i == 1
-      ssl_context = OpenSSL::SSL::SSLContext.new
-      ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)
-      ssl_socket.sync_close = true
-      ssl_socket.connect
-      ssl_socket
-    else
+      if data['ssl'].to_i == 1
+        ssl_context = OpenSSL::SSL::SSLContext.new
+        ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        ssl_socket = OpenSSL::SSL::SSLSocket.new(socket, ssl_context)
+        ssl_socket.sync_close = true
+        ssl_socket.connect
+        socket = ssl_socket
+      end
       socket
-    end
+	end
   end
 
   def format_commit_message(commit)


### PR DESCRIPTION
It's known that irc module for ejabberd sends command 001 at client's connect to server instead of expected command 004. I've investigated a bit and have discovered that possible welcome messages are all 001-004, so irc implementation should check for all of them
