### PR TITLE
Fix for wrong event title

### DIFF
--- a/services/prowl.rb
+++ b/services/prowl.rb
@@ -5,7 +5,7 @@ class Service::Prowl < Service
 
     url = URI.parse('https://api.prowlapp.com/publicapi/add')
     repository = payload['repository']['url'].split("/")
-    event = repository[-2], "/", repository[-1]
+    event = [repository[-2], repository[-1]].join('/')
     application = "GitHub"
     description = "#{payload['commits'].length} commits pushed to #{application} (#{payload['commits'][-1]['id'][0..7]}..#{payload['commits'][0]['id'][0..7]})
     


### PR DESCRIPTION
Since a few days ago, the prowl notification is being titled “Array” instead of the repo’s name as it used to. This should fix it.
