### PR TITLE
make intentation consistent in travis-hook

### DIFF
--- a/services/travis.rb
+++ b/services/travis.rb
@@ -22,11 +22,11 @@ class Service::Travis < Service
   end
 
   def scheme
-     domain_parts.size == 1 ? 'http' : domain_parts.first
+    domain_parts.size == 1 ? 'http' : domain_parts.first
   end
 
   def domain
-     domain_parts.last
+    domain_parts.last
   end
 
   protected


### PR DESCRIPTION
minor change. just something that bugged me while reading the source.

I would just be a shame if the otherwise clean hook had inconsistent indentation.
