### PR TITLE
Add a "chatty" option which, when false, only pushes to Lighthouse if the

### DIFF
--- a/services/lighthouse.rb
+++ b/services/lighthouse.rb
@@ -1,10 +1,14 @@
 class Service::Lighthouse < Service
   string  :subdomain, :project_id, :token
-  boolean :private
+  boolean :private, :chatty
 
   def receive_push
+    # matches string with square braces with content starting with # and a digit.
+    check_for_lighthouse_flags = /\[#\d.+?\]/
+    
     payload['commits'].each do |commit|
       next if commit['message'] =~ /^x /
+      next if data['chatty'] == false && (commit['message'] =~ check_for_lighthouse_flags).nil?
 
       commit_id = commit['id']
       added     = commit['added'].map    { |f| ['A', f] }


### PR DESCRIPTION
Add a "chatty" option which, when false, only pushes to Lighthouse if the commit message contains valid lighthouse flags.

**Example: Will push to Lighthouse**

``` sh
git commit -am 'Added some super cool shit [#25 state:resolved]'
```

**Example: Will NOT push to Lighthouse**

``` sh
git commit -am 'Fixed an issue that the client has not seen yet.'
```

I don't tend to write ruby, so I'm kinda winging it here. Let me know if I should change anything to make this work better.
