### PR TITLE
Bugzilla service hook

### DIFF
--- a/docs/bugzilla
+++ b/docs/bugzilla
@@ -13,7 +13,16 @@ Multiple bugs can also be specified by separating them with a comma,
 apersand, plus or "and":
   - Bug 123, 124 and 125
 
-This hook requires Bugzilla version >= 3.4 to function correctly.
+If the central repository option is enabled and there is a "fix",
+"close", or "address" before the bug then that bug is closed.
+
+If a commit has already been mentioned in the bug comments when pushed
+by another user then a comment isn't made, unless the central repository
+option is enabled. In this case only the first line of the commit message
+is included in the bug comment.
+
+This hook requires Bugzilla version >= 3.4 to function correctly
+and >= 4.0 to be able to close bugs.
 
 Settings
 --------
@@ -21,3 +30,5 @@ Settings
   - server_url - The URL for the Bugzilla installation, eg http://bugzilla.mozilla.org/
   - username - Email address for Bugzilla user account
   - password - Password for the user account
+  - central_repository - Set to true to enable closing bugs and commenting on commits that were
+    already pushed to another user's repository

--- a/test/bugzilla_test.rb
+++ b/test/bugzilla_test.rb
@@ -6,21 +6,38 @@ class BugzillaTest < Service::TestCase
   end
 
   def test_push
-    modified_payload = payload.clone()
-    #modify payload to include some bug numbers
-    modified_payload['commits'][0]['message'] << "\nBug:4"
-    modified_payload['commits'][1]['message'] << "\nTracker items 1, 2 and 3"
-    modified_payload['commits'][2]['message'] << "\nTracker item 1"
-    svc = service({'server_url' => 'nowhere', 'username' => 'someone', 'password' => '12345'}, modified_payload)
+    modified_payload = modify_payload(payload)
+    svc = service({'server_url' => 'nowhere', 'username' => 'someone', 'password' => '12345', 'central_repository' => false}, modified_payload)
     svc.xmlrpc_client = @server
     svc.receive_push
 
     assert !@server.bug_posts.include?(4) # fake server says this was already pushed somewhere else
+    assert @server.closed_bugs.length == 0 # shouldn't close any bugs because this isn't the central repository
     assert @server.bug_posts[1].include? 'Commits' #check for plural
     assert @server.bug_posts[1].include? '5057e76a11abd02e83b7d3d3171c4b68d9c88480'
     assert @server.bug_posts[1].include? 'a47fd41f3aa4610ea527dcc1669dfdb9c15c5425'
     assert @server.bug_posts[2].include? '5057e76a11abd02e83b7d3d3171c4b68d9c88480'
     assert @server.bug_posts[3].include? '5057e76a11abd02e83b7d3d3171c4b68d9c88480'
+  end
+
+  def test_central_push
+    #test pushing to a central repository
+    modified_payload = modify_payload(payload)
+    svc = service({'server_url' => 'nowhere', 'username' => 'someone', 'password' => '12345', 'central_repository' => true}, modified_payload)
+    svc.xmlrpc_client = @server
+    svc.receive_push
+
+    assert @server.closed_bugs.include?(1)
+    assert @server.bug_posts.include?(4) # fake server says this was already pushed somewhere else
+  end
+
+  def modify_payload(payload)
+    #modify payload to include some bug numbers and close a bug
+    modified_payload = payload.clone()
+    modified_payload['commits'][0]['message'] << "\nBug:4"
+    modified_payload['commits'][1]['message'] << "\nTracker items 1, 2 and 3"
+    modified_payload['commits'][2]['message'] << "\nCloses tracker item 1"
+    return modified_payload
   end
 
   def service(*args)
@@ -37,11 +54,17 @@ class BugzillaTest < Service::TestCase
       when 'Bug.comments'
         # Pretend this commit has already been pushed to another user's repository
         return {'bugs'=>{"#{arguments['ids'][0]}"=>{'comments'=>[{'text'=>'06f63b43050935962f84fe54473a7c5de7977325'}]}}}
+      when 'Bug.update'
+        closed_bugs.push *arguments['ids']
       end
     end
 
     def bug_posts
       @bug_posts ||= {}
+    end
+
+    def closed_bugs
+      @closed_bugs ||= []
     end
   end
 end


### PR DESCRIPTION
This service hook posts comments on Bugzilla bugs when a commit mentions a bug number and can also close bugs.

It's designed to be used in projects where contributors are pushing commits to their own github remote repositories but also works with just one repository.
