### PR TITLE
add very simple config.ru file

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,7 @@
+require File.expand_path('../config/load', __FILE__)
+
+Service::App.set :environment => :production,
+  :port        => ARGV.first || 8080,
+  :logging     => true
+
+run Service::App


### PR DESCRIPTION
Enables you to run github-services using rackup or passenger for
example.

The config file is basically a copy of the github-services.rb startup
script with some small modifications:
- Removed the HOSTNAME global since I didn't know what it was used for
- Removed the :run => true setting, I assume it's not needed when using
  rackup or Passenger
- Removed the checking of available servers, since I guess rackup will
  do that for you
- Changed the run call to be compatible with a config.ru file
