### PR TITLE
Add ability to specify branch for Pivotal Tracker hook

### DIFF
--- a/docs/pivotal_tracker
+++ b/docs/pivotal_tracker
@@ -5,12 +5,14 @@ Install Notes
 -------------
 
   1. token is your Pivotal Tracker API Token. This is at the bottom of your 'My Profile' page.
+  2. branch is the name of the branch you want to listen for commits on. If none is provided it will listen on all branches.
 
 Developer Notes
 ---------------
 
 data
   - token
+  - branch
 
 payload
   - refer to docs/github_payload

--- a/services/pivotal_tracker.rb
+++ b/services/pivotal_tracker.rb
@@ -1,12 +1,27 @@
 class Service::PivotalTracker < Service
-  string :token
+  string :token, :branch
 
   def receive_push
     token = data['token']
+    branch = data['branch'].to_s
+    ref = payload["ref"].to_s
 
     # need to figure out how to get the right equifax secure ca loaded
     http.ssl[:verify] = false
 
+    if branch.empty? || branch == ref.split("/").last
+      notifier.call
+    end
+  end
+
+  attr_writer :notifier
+
+  def notifier
+    @notifier ||= Proc.new { notify }
+  end
+
+  private
+  def notify
     res = http_post 'https://www.pivotaltracker.com/services/v3/github_commits' do |req|
       req.params[:token] = data['token']
       req.body = {:payload => payload.to_json}

--- a/test/pivotal_tracker_test.rb
+++ b/test/pivotal_tracker_test.rb
@@ -1,14 +1,33 @@
 require File.expand_path('../helper', __FILE__)
 
 class PivotalTrackerTest < Service::TestCase
+
   def setup
     @stubs = Faraday::Adapter::Test::Stubs.new
   end
 
-  def test_push
+  def test_mismatched_branch
+    svc = service({"branch" => "abc"}, payload)
+    svc.notifier = Proc.new { raise }
+    assert_nothing_raised { svc.receive_push }
+  end
+
+  def test_matching_branch
+    payload = {"ref" => "refs/heads/master"}
     @stubs.post "/services/v3/github_commits" do |env|
       assert_equal 'www.pivotaltracker.com', env[:url].host
-      assert_match 'payload=%7B%22a%22%3A1%7D', env[:body]
+      assert_equal "payload=#{CGI.escape(payload.to_json)}", env[:body]
+      [200, {}, '']
+    end
+
+    svc = service({"branch" => "master"}, payload)
+    svc.receive_push
+  end
+
+  def test_no_specified_branch
+    @stubs.post "/services/v3/github_commits" do |env|
+      assert_equal 'www.pivotaltracker.com', env[:url].host
+      assert_equal 'payload=%7B%22a%22%3A1%7D', env[:body]
       [200, {}, '']
     end
 


### PR DESCRIPTION
Allow users to optionally set a 'branch' option which will only send Tracker notifications when a commit is on that branch.
