### PR TITLE
Added required query string parameters and removed pre-port code.

### DIFF
--- a/services/bugly.rb
+++ b/services/bugly.rb
@@ -2,17 +2,10 @@ class Service::Bugly < Service
   string :project_id, :account_name, :token
 
   def receive_push
-    http_post "http://#{data['account_name']}.bug.ly/changesets.json",
+    http_post "http://#{data['account_name']}.bug.ly/changesets.json?service=github&project_id=#{data['project_id']}",
       JSON.generate(payload),
       'X-BuglyToken' => data['token'],
       'Content-Type' => 'application/json'
     return
-    query_string = "?service=github&project_id=#{data['project_id']}"
-    url = URI.parse("#{account}/changesets.json#{query_string}")
-    req = Net::HTTP::Post.new(url.request_uri)
-    req.body = JSON.generate(payload)
-    req.initialize_http_header({"X-BuglyToken" => data['token']})
-    req.set_content_type('application/json')
-    Net::HTTP.new(url.host, url.port).start {|http| http.request(req) }
   end
 end


### PR DESCRIPTION
Two query string parameters for the Bugly service were removed in the [June port](https://github.com/github/github-services/commit/cd3ca9145af27f980ebd04c7e914075c8a0cb377#services/bugly.rb). This commit brings them back again. This is rather urgent, since the "service=github" parameter must be present for everything to work properly.
