### PR TITLE
Use short_urls

### DIFF
--- a/services/campfire.rb
+++ b/services/campfire.rb
@@ -8,7 +8,7 @@ class Service::Campfire < Service
     return if data['master_only'].to_i == 1 and branch_name != 'master'
 
     messages = []
-    messages << "#{summary_message}: #{summary_url}"
+    messages << "#{summary_message}: #{shorten_url(summary_url)}"
     messages += commit_messages.first(8)
 
     if messages.first =~ /pushed 1 new commit/

--- a/test/campfire_test.rb
+++ b/test/campfire_test.rb
@@ -46,6 +46,7 @@ class CampfireTest < Service::TestCase
     assert_equal 't', svc.campfire.token
     assert_equal 'r', svc.campfire.rooms.first.name
     assert_equal 4, svc.campfire.rooms.first.lines.size # 3 + summary
+    assert svc.campfire.rooms.first.lines.first.match(/short/)
   end
 
   def test_push_non_master_with_master_only
@@ -67,7 +68,14 @@ class CampfireTest < Service::TestCase
   end
 
   def service(*args)
-    super Service::Campfire, *args
+    svc = super(Service::Campfire, *args)
+    class << svc
+      def shorten_url(*args)
+        'short'
+      end
+    end
+
+    svc
   end
 end
 


### PR DESCRIPTION
Instead of using the long compare URL's trying to make the room less noisy and use short URL's. Also, adding spacing around the commit URL, a lot of clients think its part of the URL
