### PR TITLE
Adding long_url support for the Campfire service

### DIFF
--- a/services/campfire.rb
+++ b/services/campfire.rb
@@ -1,14 +1,15 @@
 class Service::Campfire < Service
   string :subdomain, :room, :token
-  boolean :master_only, :play_sound
+  boolean :master_only, :play_sound, :long_url
 
   def receive_push
     raise_config_error 'Missing campfire token' if data['token'].to_s.empty?
 
     return if data['master_only'].to_i == 1 and branch_name != 'master'
 
+    url = data['long_url'].to_i == 1 ? summary_url : shorten_url(summary_url)
     messages = []
-    messages << "#{summary_message}: #{shorten_url(summary_url)}"
+    messages << "#{summary_message}: #{url}"
     messages += commit_messages.first(8)
 
     if messages.first =~ /pushed 1 new commit/

--- a/test/campfire_test.rb
+++ b/test/campfire_test.rb
@@ -49,6 +49,13 @@ class CampfireTest < Service::TestCase
     assert svc.campfire.rooms.first.lines.first.match(/short/)
   end
 
+  def test_long_url
+    svc = service({"token" => "t", "subdomain" => "s", "room" => "r", "long_url" => "1"}, payload)
+    svc.campfire = MockCampfire.new
+    svc.receive_push
+    assert svc.campfire.rooms.first.lines.first.match(/github\.com/), "Summary url should not be shortened"
+  end
+
   def test_push_non_master_with_master_only
     non_master_payload = payload
     non_master_payload["ref"] = "refs/heads/non-master"


### PR DESCRIPTION
Adding long_url support for the campfire service based on comments from Pull Request #151 and to follow the same convention as in the IRC service
