### PR TITLE
Added support to send push notifications to Android Devices through NotifyMyAndroid

### DIFF
--- a/docs/notifymyandroid
+++ b/docs/notifymyandroid
@@ -1,0 +1,20 @@
+Notify My Android
+==========
+
+With NotifyMyAndroid (NMA) you can push notifications to your Android devices, through Google's C2DM notification system. The public Web API (http://www.notifymyandroid.com/api.php) can be used by virtually any application to delivery push notifications to your Android.
+
+Install Notes
+-------------
+
+1. Register at https://www.notifymyandroid.com/register.php.
+
+2. Generate an API key at https://www.notifymyandroid.com/account.php to be used on Github.
+
+Developer Notes
+---------------
+
+apikey
+  - Your NMA API Key, or a CSV list of API Keys.
+
+payload
+  - refer to docs/github_payload

--- a/services/notifymyandroid.rb
+++ b/services/notifymyandroid.rb
@@ -1,0 +1,21 @@
+class Service::NMA < Service
+  string :apikey
+
+  def receive_push
+    url = URI.parse('https://www.notifymyandroid.com/publicapi/notify')
+    repository = payload['repository']['url'].split("/")
+    event = [repository[-2], repository[-1]].join('/')
+    application = "GitHub"
+    description = "#{payload['commits'].length} commits pushed to #{application} (#{payload['commits'][-1]['id'][0..7]}..#{payload['commits'][0]['id'][0..7]})
+    
+  Latest Commit by #{payload['commits'][-1]['author']['name']}
+  #{payload['commits'][-1]['id'][0..7]} #{payload['commits'][-1]['message']}"
+
+    http_post 'https://www.notifymyandroid.com/publicapi/notify',
+      :apikey => data['apikey'],
+      :application => application,
+      :event => event,
+      :description => description,
+      :url => payload['compare']
+  end
+end

--- a/test/notifymyandroid_test.rb
+++ b/test/notifymyandroid_test.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../helper', __FILE__)
+
+class NMATest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    @stubs.post "/publicapi/notify" do |env|
+      assert_equal 'www.notifymyandroid.com', env[:url].host
+      data = Rack::Utils.parse_query(env[:body])
+      assert_equal 'a', data['apikey']
+      [200, {}, '']
+    end
+
+    svc = service({'apikey' => 'a'}, payload)
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::NMA, *args
+  end
+end
+


### PR DESCRIPTION
Service hook to NotifyMyAndroid (http://www.notifymyandroid.com)

This enables Github to send Android push notifications.

The API is really simple and all you will need to do is add an API key to enable the Service Hook.

To generate an API key, just go to https://www.notifymyandroid.com/account.php .
