### PR TITLE
Created a service-hook for Pachube

### DIFF
--- a/docs/pachube
+++ b/docs/pachube
@@ -1,0 +1,23 @@
+Pachube
+=======
+
+Publishes number of distinct commits per push to a Pachube feed.
+Datastreams are created / updated for each repository name.
+
+Install Notes
+-------------
+
+  1. Create a feed on Pachube
+  2. Create an api key that has PUT permissions on the feed
+
+
+Developer Notes
+---------------
+
+data
+  - api_key
+  - feed_id
+
+payload
+  - refer to docs/github_payload
+

--- a/services/pachube.rb
+++ b/services/pachube.rb
@@ -1,0 +1,21 @@
+class Service::Pachube < Service
+  string :api_key
+  string :feed_id
+
+  def receive_push
+    raise_config_error "Missing api_key" if data['api_key'].to_s.empty?
+    raise_config_error "Missing feed_id" if data['feed_id'].to_s.empty?
+
+    http_method :put, "https://api.pachube.com/v2/feeds/#{data['feed_id']}.json" do |req|
+      req.headers['X-PachubeApiKey'] = data['api_key']
+      req.body = {
+        :version => '1.0.0',
+        :datastreams => [
+          {
+            :id => repo_name,
+            :current_value => distinct_commits.size
+          }
+        ]}.to_json
+    end
+  end
+end

--- a/test/pachube_test.rb
+++ b/test/pachube_test.rb
@@ -1,0 +1,40 @@
+require File.expand_path('../helper', __FILE__)
+
+class PachubeTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_require_api_key
+    svc = service({}, payload)
+    assert_raises Service::ConfigurationError do
+      svc.receive_push
+    end
+  end
+
+  def test_require_feed_id
+    svc = service({'api_key' => 'abcd1234'}, payload)
+    assert_raises Service::ConfigurationError do
+      svc.receive_push
+    end
+  end
+
+  def test_push
+    @stubs.put "/v2/feeds/1234.json" do |env|
+      assert_equal 'api.pachube.com', env[:url].host
+      assert_equal 'https', env[:url].scheme
+      parsed_body = JSON.parse(env[:body])
+      assert_equal '1.0.0', parsed_body['version']
+      assert_equal [{'current_value' => 3, 'id' => 'grit'}], parsed_body['datastreams']
+      [200, {}, '']
+    end
+
+    svc = service({'api_key' => 'abcd1234', 'feed_id' => '1234'}, payload)
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::Pachube, *args
+  end
+end
+


### PR DESCRIPTION
We're a 'Real-Time Open Data Web Service for the Internet of Things'

So basically https://pachube.com is an api that allows low-level embedded devices to communicate / share data on the web.

Although we're primarily aimed at internet enabled devices that don't have screens or sophisticated operating systems (think arduino etc.) there's no need our api can't be used to track / graph all sorts of stats, including commit activity!

This initial version only sends the number of distinct commits per push, but there's no reason we won't expand that in the future.

Cheers
Levent 
