### PR TITLE
Gemnasium service hook

### DIFF
--- a/docs/gemnasium
+++ b/docs/gemnasium
@@ -1,0 +1,22 @@
+Gemnasium
+=========
+
+Install Notes
+-------------
+
+Gemnasium notifies you when new versions are released for your GitHub repositories' gem dependencies.
+
+----
+
+1.  Enter your GitHub name
+2.  Create an account on [gemnasium.com](http://gemnasium.com/)
+3.  Enter your API key (from [gemnasium.com/account](http://gemnasium.com/account))
+4.  Check "Active"
+5.  Click "Update Settings"
+
+Developer Notes
+---------------
+
+    data
+      - name
+      - token

--- a/services/gemnasium.rb
+++ b/services/gemnasium.rb
@@ -1,0 +1,36 @@
+class Service::Gemnasium < Service
+  string :user, :token
+
+  def receive_push
+    http.basic_auth(user, signature)
+    http_post(url, body, headers)
+  end
+
+  def http(*)
+    super.tap{|h| h.builder.delete(Faraday::Request::UrlEncoded) }
+  end
+
+  def user
+    data["user"].strip
+  end
+
+  def signature
+    Digest::SHA2.hexdigest(token + body)
+  end
+
+  def token
+    data["token"].strip.downcase
+  end
+
+  def body
+    payload.to_json
+  end
+
+  def url
+    "http://gemnasium.com/repositories/hook"
+  end
+
+  def headers
+    {:content_type => "application/json"}
+  end
+end

--- a/test/gemnasium_test.rb
+++ b/test/gemnasium_test.rb
@@ -1,0 +1,50 @@
+require File.expand_path("../helper", __FILE__)
+
+class GemnasiumTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_stripped_user
+    svc = service("user" => " laserlemon ")
+    assert_equal "laserlemon", svc.user
+  end
+
+  def test_stripped_token
+    svc = service("token" => " abc ")
+    assert_equal "abc", svc.token
+  end
+
+  def test_downcased_token
+    svc = service("token" => "ABC")
+    assert_equal "abc", svc.token
+  end
+
+  def test_body
+    svc = service({}, {"pay" => "load"})
+    assert_equal '{"pay":"load"}', svc.body
+  end
+
+  def test_signature
+    svc = service({"token" => "abc"}, {"pay" => "load"})
+    assert_equal "f329edd3feef6b4504c15ee4af6cb65ba28de90ba690001e3a548c5dddf80990", svc.signature
+  end
+
+  def test_push
+    svc = service({"user" => "laserlemon", "token" => "abc"}, {"pay" => "load"})
+
+    @stubs.post "/repositories/hook" do |env|
+      assert_equal "gemnasium.com", env[:url].host
+      assert_equal "application/json", env[:request_headers][:content_type]
+      assert_equal "Basic bGFzZXJsZW1vbjpmMzI5ZWRkM2ZlZWY2YjQ1MDRjMTVlZTRhZjZjYjY1YmEyOGRlOTBiYTY5MDAwMWUzYTU0OGM1ZGRkZjgwOTkw", env[:request_headers][:authorization]
+      assert_equal '{"pay":"load"}', env[:body]
+    end
+
+    svc.receive_push
+  end
+
+  private
+    def service(data, payload = payload)
+      super(Service::Gemnasium, data, payload)
+    end
+end


### PR DESCRIPTION
I'm building a new service and launch is right around (weeks) around the corner, so I want to preemptively add this service hook. It'll be required for launch. I'll be hitting up the IRCs when I need it in the UI but I'm also wondering if it'll become available via the service hooks API at that same time. Thank you!
