### PR TITLE
Fix sample message to prevent 'bleeding' of notes on GitHub service admin

### DIFF
--- a/docs/twilio
+++ b/docs/twilio
@@ -4,7 +4,7 @@ Twilio
 Allows you to setup a GitHub repository to send out SMS messages on git pushes.
 Currently the SMS message is built to say:
 
-"#{payload['pusher']['name']} has pushed #{payload['commits'].size} commit(s) to #{payload['repository']['name']}"
+[pusher name] has pushed [# commits] commit(s) to [repository name]
 
 Install Notes
 -------------


### PR DESCRIPTION
Fix sample message to prevent 'bleeding' of notes on GitHub service admin page. I didn't realize the previous text wouldn't wrap. The following sample message should fit within the allotted space and not bleed over the edge.

Apologies.
