### PR TITLE
Removed SSL dependency from service-hook

### DIFF
--- a/services/leanto.rb
+++ b/services/leanto.rb
@@ -2,7 +2,7 @@ class Service::Leanto < Service
   string :token
 
   def receive_push
-    res = http_post "https://www.lean-to.com/api/%s/commit" %
+    res = http_post "http://www.lean-to.com/api/%s/commit" %
       [ data['token'] ],
       {'payload' => payload.to_json}
 


### PR DESCRIPTION
Lean-to no longer requires GitHub service-hooks to be sent over https
