### PR TITLE
Add option to only notify on commits to master for Twilio.

### DIFF
--- a/docs/twilio
+++ b/docs/twilio
@@ -13,6 +13,7 @@ Install Notes
 2. You can find your account_sid and auth_token on your account page at https://www.twilio.com/user/account
 3. from_phone must be a "Twilio phone number enabled for SMS. Only phone numbers or short codes purchased from Twilio work here"
 4. to_phone is the "destination phone number. Format with a '+' and country code e.g., +16175551212 (E.164 format)."
+5. Check master_only if you only want to recieve updates for master
 
 Developer Notes
 ---------------
@@ -22,6 +23,7 @@ data
   - auth_token
   - from_phone
   - to_phone
+  - master_only
 
 payload
   - refer to docs/github_payload

--- a/services/twilio.rb
+++ b/services/twilio.rb
@@ -1,25 +1,38 @@
 class Service::Twilio < Service
   string   :account_sid, :from_phone, :to_phone
+  boolean  :master_only
   password :auth_token
-  
+
   def receive_push
     check_configuration_options(data)
-    
+
     sms_body = "#{payload['pusher']['name']} has pushed #{payload['commits'].size} commit(s) to #{payload['repository']['name']}"
-    client = ::Twilio::REST::Client.new(data['account_sid'], data['auth_token'])
-    client.account.sms.messages.create(
-      :from => data['from_phone'],
-      :to => data['to_phone'],
-      :body => sms_body
-    )
+    send_message(data, sms_body) if send_notification?(data)
   end
-  
+
   private
-  
+
+  def send_notification?(data)
+    notify_user = true
+    if data['master_only'].to_i == 1 && branch_name != 'master'
+      notify_user = false
+    end
+    notify_user
+  end
+
   def check_configuration_options(data)
     raise_config_error 'Account SID must be set' if data['account_sid'].blank?
     raise_config_error 'Authorization token must be set' if data['auth_token'].blank?
     raise_config_error 'Twilio-enabled phone number or short code must be set' if data['from_phone'].blank?
     raise_config_error 'Destination phone number must be set' if data['to_phone'].blank?
+  end
+
+  def send_message(data, message)
+    client = ::Twilio::REST::Client.new(data['account_sid'], data['auth_token'])
+    client.account.sms.messages.create(
+      :from => data['from_phone'],
+      :to => data['to_phone'],
+      :body => message
+    )
   end
 end


### PR DESCRIPTION
Was annoyed that everyone on my repository was getting notified when I committed to personal branches, so I added an option to only notify on master.

I was not able to run the service locally due to compatibility issues with thin and snow leopard. But I did write tests, so it looks like everything is working fine.

Let me know if you have any questions.
