### PR TITLE
Add multi-project support for Bamboo

### DIFF
--- a/docs/bamboo
+++ b/docs/bamboo
@@ -14,6 +14,13 @@ Install Notes
 
   3.  "build_key" is the identifier of the plan you want to trigger
       Example: "BAM-TRUNK", where BAM = project key, TRUNK = plan key
+      
+      A compound build key value can be used to specify multiple builds or associate
+      specific branches with a build
+      Example: "master:BAM-TRUNK,3-2-patches:BAM-32PATCH,BAM-TESTS", where BAM-TRUNK 
+      will be triggered only by pushes to the master branch, BAM-32PATCH will only
+      be triggered by pushes to the 3-2-patches branch, and BAM-TESTS will be triggered
+      for any push.
 
   4.  "username" and "password" - username and password of a Bamboo user that can
       trigger a manual build of the Bamboo plan defined in "build_key"


### PR DESCRIPTION
Provide for a compound build-key parameter which can be used to specify
multiple bamboo builds and associate git branches with specific builds
