### PR TITLE
Pivotal support for watching multiple branches.

### DIFF
--- a/docs/pivotal_tracker
+++ b/docs/pivotal_tracker
@@ -5,7 +5,7 @@ Install Notes
 -------------
 
   1. token is your Pivotal Tracker API Token. This is at the bottom of your 'My Profile' page.
-  2. branch is the name of the branch you want to listen for commits on. If none is provided it will listen on all branches.
+  2. branch is a space-separated list of the branches you want to listen for commits on. If none is provided it will listen on all branches.
 
 Developer Notes
 ---------------

--- a/services/pivotal_tracker.rb
+++ b/services/pivotal_tracker.rb
@@ -3,10 +3,10 @@ class Service::PivotalTracker < Service
 
   def receive_push
     token = data['token']
-    branch = data['branch'].to_s
+    branches = data['branch'].to_s.split(/\s+/)
     ref = payload["ref"].to_s
 
-    if branch.empty? || branch == ref.split("/").last
+    if branches.empty? || branches.include?(ref.split("/").last)
       notifier.call
     end
   end


### PR DESCRIPTION
We're on a longer rewrite-style project and are fixing bugs there until we merge back to master (while still doing bug fixes in master). We'd like to communicate back to Pivotal tracker not just on a single watched branch, but on a space separated list of branches (allowing us to use post commit hooks to work for the whole team).
