### PR TITLE
Add support for multiple email addresses to email service hook

### DIFF
--- a/docs/email
+++ b/docs/email
@@ -4,7 +4,7 @@ Email
 Install Notes
 -------------
 
-1. `address(es)` whitespace separated list of email addresses
+1. `address(es)` whitespace separated email addresses (at most two)
 2. `secret` fills out the Approved header to automatically approve the message
    in a read-only or moderated mailing list.
 3. `send_from_author` uses the commit author email address in the From address of the email.

--- a/services/email.rb
+++ b/services/email.rb
@@ -65,7 +65,7 @@ class Service::Email < Service
     commit = payload['commits'].last # assume that the last committer is also the pusher
 
     begin
-      data['addresses'].split(' ').each do |address|
+      data['addresses'].split(' ').slice(0, 2).each do |address|
         message = TMail::Mail.new
         message.set_content_type('text', 'plain', {:charset => 'UTF-8'})
         message.from = "#{commit['author']['name']} <#{commit['author']['email']}>" if data['send_from_author']

--- a/test/email_test.rb
+++ b/test/email_test.rb
@@ -17,7 +17,7 @@ class EmailTest < Service::TestCase
 
   def test_multiple_addresses
     svc = service(
-      {'addresses' => ' a b '},
+      {'addresses' => ' a b c'},
       payload)
 
     svc.receive_push
@@ -30,6 +30,7 @@ class EmailTest < Service::TestCase
     assert_match "noreply@github.com", from
     assert_equal 'b', to
 
+    # 3rd address ignored
     assert_nil svc.messages.shift
   end
 


### PR DESCRIPTION
- Rename address to addresses
- Split addresses on whitespace and loop
- Update test code and add trivial test case
