### PR TITLE
add simple loggly service

### DIFF
--- a/docs/loggly
+++ b/docs/loggly
@@ -1,0 +1,19 @@
+Loggly
+========
+
+This service hook allows you to log pushed commits directly to a Loggly HTTP
+input. 
+
+Install Notes
+-------------
+
+  1. input token -- take this from the detail page for your HTTP input.
+
+Developer Notes
+---------------
+
+data
+  - input_token
+
+payload
+  - refer to docs/github_payload

--- a/services/loggly.rb
+++ b/services/loggly.rb
@@ -1,0 +1,12 @@
+class Service::Loggly < Service
+    string :input_token
+
+    def receive_push
+        http.headers['Content-Type'] = 'application/json'
+        url = "https://logs.loggly.com/inputs/#{data['input_token']}"
+        payload['commits'].each { |commit| http_post url, commit.to_json }
+    end
+end
+  
+
+

--- a/test/loggly.rb
+++ b/test/loggly.rb
@@ -1,0 +1,22 @@
+class JiraTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    @stubs.post "/inputs/input-foo" do |env|
+      assert_equal 'application/json', env[:request_headers]['Content-Type']
+      assert_equal 'logs.loggly.com', env[:url].host
+      [200, {}, '']
+    end
+
+    svc = service(
+      {"input_token" => "input-foo"},
+      payload)
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::Loggly, *args
+  end
+end


### PR DESCRIPTION
On push, log individual commits to a Loggly HTTP input.
