### PR TITLE
Add simple service for Github Pages blog

### DIFF
--- a/docs/pages_twitter
+++ b/docs/pages_twitter
@@ -30,4 +30,5 @@ The secrets.yml file should include an entry for the consumer keys github needs 
       key: <get it from twitter> 
       secret: <get it from twitter>
 
-The domain name can be taken from the CNAME file automatically
+The domain field is required. It contains custom domain or '<repository_owner>.github.com'
+The custom domain name can be taken from the CNAME file automatically.

--- a/services/pages_twitter.rb
+++ b/services/pages_twitter.rb
@@ -4,31 +4,34 @@ class Service::PagesTwitter < Service
   def receive_push
     
     # 
-    # We need to run this hook only for one case:
+    # We need to run this hook only for two cases:
     #   1. push to <repository_owner>.github.com/master
+    #   2. push to <repository_name>/gh-pages
     #
 
     #
     # Checking branches from the list above 
     #
 
-    branch = payload['ref'].split('/').last # Name of the pushed branch    
+    branch = payload['ref'].split('/').last # Name of the pushed branch
     repository = payload['repository']['name']  # Name of the pushed repository
-    owner_name = payload['repository']['owner']['name'] # Name of repository owner
-    if !(branch == "master" && repository == owner_name + ".github.com")
-      # If we are here the branch doesn't need this hook
-      # 
-      # Exit hook
-      # 
-      return 1
+    if branch != 'gh-pages'    
+      owner_name = payload['repository']['owner']['name'] # Name of repository owner
+      if !(branch == "master" && repository == owner_name + ".github.com")
+        # If we are here the branch doesn't need this hook
+        # 
+        # Exit hook
+        # 
+        return 1
+      end
     end
 
     #
-    # domain is custom domain of github pages taken from CNAME file.
-    # If it's nil then using the repository name
+    # domain is custom domain of github pages taken from CNAME file or 
+    # <repository_owner>.github.com
     #
     
-    domain = data['domain'] ? data['domain'] : repository
+    domain = data['domain']
     
     #
     # Now we need to check added files in the each commit
@@ -44,10 +47,10 @@ class Service::PagesTwitter < Service
       if commit['message'][0..5].downcase == "[post]"
         commit['added'].each do |file|
           blocks = file.match(/^(.+\/)*(\d+)-(\d+)-(\d+)-(.*)(\.[^.]+)$/)
-          if blocks && blocks.values_at(1) == "_posts/"
+          if blocks
             year,month,day,postname = *(blocks.values_at(-5,-4,-3,-2))
             post_anounce = commit['message'][6..-1]
-            tuny_url = shorten_url("#{url_path(domain,year,month,day,postname)}")
+            tuny_url = shorten_url("#{domain_way(branch, repository, domain)}/#{url_path(year,month,day,postname)}")
             status = tuny_url + " " + post_anounce
             status.length >= 140 ? statuses << status[0..136] + '...' : statuses << status
           else
@@ -63,9 +66,17 @@ class Service::PagesTwitter < Service
     
   end
   
+  def domain_way(branch, repository, domain)
+    if branch == 'master'
+      return "#{domain}"
+    end
+    if branch == 'gh-pages'
+      return "#{domain}/#{repository}"
+    end
+  end
   
-  def url_path(domain,year,month,day,postname)
-    "#{domain}/#{year}/#{month}/#{day}/#{postname}.html"
+  def url_path(year,month,day,postname)
+    "#{year}/#{month}/#{day}/#{postname}.html"
   end
   
   #


### PR DESCRIPTION
This service provides basic functionality for automatic sending of tweet after pushing a new blog entry.
On pushing it sends the tweet about a new entry in the blog.
