### PR TITLE
AgileZen integration hook

### DIFF
--- a/services/agilezen.rb
+++ b/services/agilezen.rb
@@ -6,6 +6,7 @@ class Service::AgileZen < Service
     raise_config_error "Missing 'project_id'" if data['project_id'].to_s == ''
 
     http.headers['X-Zen-ApiKey'] = data['api_key']
+    http.headers['Content-Type'] = 'application/json'
 
     res = http_post "https://agilezen.com/api/v1/projects/#{data['project_id']}/changesets/github",
       JSON.generate(payload)

--- a/test/agilezen_test.rb
+++ b/test/agilezen_test.rb
@@ -1,0 +1,23 @@
+require File.expand_path('../helper', __FILE__)
+
+class AgileZenTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    @stubs.post '/api/v1/projects/123/changesets/github' do |env|
+      assert_equal %({"answer":42}),   env[:body]
+      assert_equal 'test_api_key',     env[:request_headers]['X-Zen-ApiKey']
+      assert_equal 'application/json', env[:request_headers]['Content-Type']
+      [200, {}, '']
+    end
+
+    svc = service({'api_key' => 'test_api_key', 'project_id' => '123'}, 'answer' => 42)
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::AgileZen, *args
+  end
+end


### PR DESCRIPTION
Hi GitHub! :)

We've just shipped a simple integration between GitHub and our product, AgileZen. It's just a simple hook that associates GitHub commits with story cards in our system. I've attached the hook code, which I've tested with our production system. Is there anything else that we need to do to be listed on the list of service hooks?

If you have any questions or need anything else from us, feel free to shoot me an email at natekohari@rallydev.com. By the way, we (and I) love your service. Keep being awesome.

Thanks,
Nate
