### PR TITLE
Improved the Twitter service

### DIFF
--- a/services/twitter.rb
+++ b/services/twitter.rb
@@ -10,13 +10,13 @@ class Service::Twitter < Service
       commit = payload['commits'][-1]
       author = commit['author'] || {}
       tiny_url = shorten_url("#{payload['repository']['url']}/commits/#{ref_name}")
-      status = "[#{repository}] #{tiny_url} #{author['name']} - #{payload['commits'].length} commits"
+      status = "[#{repository}@#{ref_name}] #{tiny_url} #{author['name']} – #{payload['commits'].length} commits"
       status.length >= 140 ? statuses << status[0..136] + '...' : statuses << status
     else
       payload['commits'].each do |commit|
         author = commit['author'] || {}
         tiny_url = shorten_url(commit['url'])
-        status = "[#{repository}] #{tiny_url} #{author['name']} - #{commit['message']}"
+        status = "[#{repository}@#{ref_name}] #{tiny_url} #{author['name']} – #{commit['message']}"
         status.length >= 140 ? statuses << status[0..136] + '...' : statuses << status
       end
     end


### PR DESCRIPTION
Just two simple improvements:
- Show the branch name of the commit(s) in the tweet
- Use a dash instead of a minus. This just looks better.

Example:

>  [steam-condenser-ruby@update-api] git.io/Drgvag Sebastian Staudt – 1 commits
