### PR TITLE
Add Ducksboard service hook.

### DIFF
--- a/docs/ducksboard
+++ b/docs/ducksboard
@@ -1,0 +1,13 @@
+Ducksboard
+==========
+
+Get commits, issues and other real-time notifications in your Ducksboard GitHub widgets.
+
+More info at http://ducksboard.com/.
+
+Install Notes
+-------------
+
+See https://ducksboard.jira.com/wiki/display/webhooks/GitHub for detailed instructions.
+
+  Webhook Key can be found in the widget settings, "Webhook Support" tab.

--- a/services/ducksboard.rb
+++ b/services/ducksboard.rb
@@ -1,0 +1,50 @@
+class Service::Ducksboard < Service
+  string :webhook_key
+
+  def receive_push
+    # As simple as it can get: just build a ducksboard webhooks url from
+    # the webhook_key config param and send the whole payload, ducksboard
+    # will know what to do with it.
+    # Why not using a POST-receive url then? Because we are interested in
+    # more events than just pushes!
+
+    # webhook key sanity check
+    webhook_key = check_webhook_key(data)
+
+    url = "https://webhooks.ducksboard.local/#{webhook_key}"
+
+    http.headers['content-type'] = 'application/x-www-form-urlencoded'
+    body = Faraday::Utils.build_nested_query(
+      http.params.merge(:payload => JSON.generate(payload)))
+
+    http_post url, body
+
+  rescue EOFError
+    raise_config_error "Invalid server response."
+  end
+
+  alias receive_issues receive_push
+  alias receive_fork receive_push
+  alias receive_watch receive_push
+
+  def check_webhook_key(data)
+    # the webhook key is required
+    if !data['webhook_key']
+      raise_config_error "Invalid webhook key"
+    end
+
+    # we do accept ducksboard webhook urls from which the key will be extracted
+    webhook_key = data['webhook_key']
+    if webhook_key =~ /^https\:\/\/webhooks\.ducksboard\.com\//
+      webhook_key = URI.parse(webhook_key).path[1..-1]
+    end
+
+    # only alphanumeric hex keys are valid
+    if webhook_key !~ /^[a-fA-F0-9]+$/
+      raise_config_error "Invalid webhook key"
+    end
+
+    webhook_key
+  end
+
+end

--- a/test/ducksboard_test.rb
+++ b/test/ducksboard_test.rb
@@ -1,0 +1,58 @@
+class DucksboardTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_receive
+    # Our service is pretty simple, and so is the test: just check that
+    # the original payload is received on our side, where the parsing
+    # will happen.
+    svc = service({
+      'webhook_key' => '1234abcd'
+    }, payload)
+
+    @stubs.post '/1234abcd' do |env|
+      body = Rack::Utils.parse_nested_query(env[:body])
+      recv = JSON.parse(body['payload'])
+      assert_equal payload, recv
+      [200, {}, '']
+    end
+
+    svc.receive
+  end
+
+  def test_webhook_key_through_url
+    svc = service({
+      'webhook_key' => 'https://webhooks.ducksboard.com/abcd1234'
+    }, payload)
+
+    @stubs.post '/abcd1234' do |env|
+      body = Rack::Utils.parse_nested_query(env[:body])
+      recv = JSON.parse(body['payload'])
+      assert_equal payload, recv
+      [200, {}, '']
+    end
+
+    svc.receive
+  end
+
+  def test_missing_webhook_key
+    svc = service({}, payload)
+    assert_raise Service::ConfigurationError do
+      svc.receive
+    end
+  end
+
+  def test_invalid_webhook_key
+    svc = service({
+      'webhook_key' => 'foobar' # non-hex values
+    }, payload)
+    assert_raise Service::ConfigurationError do
+      svc.receive
+    end
+  end
+
+  def service(*args)
+    super Service::Ducksboard, *args
+  end
+end


### PR DESCRIPTION
Will send pushes, issues, forks and watches notifications to Ducksboard
widgets which will display the updates in real-time.

Ducksboard is a real-time dashboard for SaaS metrics. See more at
http://ducksboard.com/.
