### PR TITLE
Fixed TargetProcess hook's regular expression

### DIFF
--- a/services/target_process.rb
+++ b/services/target_process.rb
@@ -28,7 +28,7 @@ private
   def process_commit(commit)
     author = commit["author"]["email"]    
     commit["message"].split("\n").each { |commit_line|
-      parts = commit_line.match(/(\s|^)#(\d+):?([^\s]+)?(.*)/)
+      parts = commit_line.match(/(\s|^)#(\d+)(:[^\s]+)?(\s|$)/)
       next if parts.nil?
       entity_id = parts[2].strip
       next if entity_id.nil? or entity_id.length == 0


### PR DESCRIPTION
I tweaked the regular expression in the TP service hook so it should properly skip over poorly-formatted commit messages now.  For example `#1142Fixed` (which should read `#1142:Fixed`) will no longer trigger the hook to update the bug/feature/story/task with ID 1142 as fixed.

Extra messages are also no longer required to appear after the `#id:state` keyword, so messages like `Fixed JonnyFunFun's bad code #12:Fixed` will now pass through to TargetProcess successfully.
