### PR TITLE
AgileZen support for watching specific branches

### DIFF
--- a/docs/agilezen
+++ b/docs/agilezen
@@ -12,6 +12,7 @@ Install Notes
 
 1. **API Key** - This is your AgileZen API key.
 2. **Project ID** - This is the project's numeric ID (the number in the project's URL on AgileZen) to associate with the repository.
+3. **Branches** - This is a space-separated list of branches to watch commits for. Commits to other branches will not be notified to AgileZen.
 
 Need Help?
 ----------

--- a/services/agilezen.rb
+++ b/services/agilezen.rb
@@ -1,9 +1,13 @@
 class Service::AgileZen < Service
-  string :api_key, :project_id
+  string :api_key, :project_id, :branches
 
   def receive_push
     raise_config_error "Missing 'api_key'"    if data['api_key'].to_s == ''
     raise_config_error "Missing 'project_id'" if data['project_id'].to_s == ''
+
+    branches = data['branches'].to_s.split(/\s+/)
+    ref = payload["ref"].to_s
+    return unless branches.empty? || branches.include?(ref.split("/").last)
 
     http.headers['X-Zen-ApiKey'] = data['api_key']
     http.headers['Content-Type'] = 'application/json'

--- a/test/agilezen_test.rb
+++ b/test/agilezen_test.rb
@@ -5,16 +5,77 @@ class AgileZenTest < Service::TestCase
     @stubs = Faraday::Adapter::Test::Stubs.new
   end
 
-  def test_push
+  def test_unspecified_branch
+    payload = {'answer' => 42, 'ref' => 'refs/heads/master'}
     @stubs.post '/api/v1/projects/123/changesets/github' do |env|
-      assert_equal %({"answer":42}),   env[:body]
+      assert_equal payload.to_json,   env[:body]
       assert_equal 'test_api_key',     env[:request_headers]['X-Zen-ApiKey']
       assert_equal 'application/json', env[:request_headers]['Content-Type']
       [200, {}, '']
     end
 
-    svc = service({'api_key' => 'test_api_key', 'project_id' => '123'}, 'answer' => 42)
+    svc = service({'api_key' => 'test_api_key', 'project_id' => '123'}, payload)
     svc.receive_push
+    @stubs.verify_stubbed_calls
+  end
+
+  def test_matching_branch
+    payload = {"ref" => "refs/heads/foo"}
+    @stubs.post("/api/v1/projects/123/changesets/github") { |e| [200, {}, ''] }
+
+    svc = service({'api_key' => 'test_api_key', 'project_id' => '123', 'branches' => 'foo'}, payload)
+    svc.receive_push
+    @stubs.verify_stubbed_calls
+  end
+
+  def test_unmatching_branch
+    payload = {"ref" => "refs/heads/bar"}
+    @stubs.post("/api/v1/projects/123/changesets/github") { |e| [200, {}, ''] }
+
+    svc = service({'api_key' => 'test_api_key', 'project_id' => '123', 'branches' => 'foo'}, payload)
+    svc.receive_push
+
+    # Test that no post fired
+    begin
+      @stubs.verify_stubbed_calls
+    rescue RuntimeError
+    else
+      assert_true false
+    end
+  end
+
+  def test_matching_branch_of_many
+    payload = {"ref" => "refs/heads/foo"}
+    @stubs.post("/api/v1/projects/123/changesets/github") { |e| [200, {}, ''] }
+
+    svc = service({'api_key' => 'test_api_key', 'project_id' => '123', 'branches' => 'baz foo'}, payload)
+    svc.receive_push
+    @stubs.verify_stubbed_calls
+  end
+
+  def test_unmatching_branch_of_many
+    payload = {"ref" => "refs/heads/bar"}
+    @stubs.post("/api/v1/projects/123/changesets/github") { |e| [200, {}, ''] }
+
+    svc = service({'api_key' => 'test_api_key', 'project_id' => '123', 'branches' => 'baz foo'}, payload)
+    svc.receive_push
+
+    # Test that no post fired
+    begin
+      @stubs.verify_stubbed_calls
+    rescue RuntimeError
+    else
+      assert_true false
+    end
+  end
+
+  def test_matching_tag
+    payload = {"ref" => "refs/tags/foo"}
+    @stubs.post("/api/v1/projects/123/changesets/github") { |e| [200, {}, ''] }
+
+    svc = service({'api_key' => 'test_api_key', 'project_id' => '123', 'branches' => 'foo'}, payload)
+    svc.receive_push
+    @stubs.verify_stubbed_calls
   end
 
   def service(*args)


### PR DESCRIPTION
Our team works on multiple remote topic branches that contain commits that reference AgileZen stories. Since these branches often get rebased or rewritten before being brought into master, AgileZen will create "duplicate" commits on the story.

These changes allow you to specify a branch ("master") or a list of branches ("master foo") for AgileZen to track. All other commits will be ignored by AgileZen.

Also, tags will work in place of branches.
