### PR TITLE
Add HTTP support to Unfuddle service

### DIFF
--- a/docs/unfuddle
+++ b/docs/unfuddle
@@ -27,4 +27,4 @@ data
   - subdomain
   - username    (Unfuddle API account holder)
   - password    (Unfuddle API account password)
-  - ssl         (Unfuddle account with SSL support)
+  - httponly    (Unfuddle accounts mostly support HTTPS; HTTP can be used for accounts where HTTPS is not supported)

--- a/services/unfuddle.rb
+++ b/services/unfuddle.rb
@@ -1,17 +1,17 @@
 class Service::Unfuddle < Service
   string   :subdomain, :repo_id, :username
   password :password
-  boolean  :ssl
+  boolean  :httponly
 
   def receive_push
     u_repoid    = data['repo_id'].to_i
     repository  = payload['repository']['name']
     branch      = branch_name
     before      = payload['before']
-    # use https for accounts that support SSL
-    scheme      = "http#{(data['ssl'].to_i == 1 && 's') || ''}"
+    # use https by default since most accounts support SSL
+    protocol    = data['httponly'].to_i == 1 ? 'http' : 'https'
 
-    http.url_prefix = "#{scheme}://#{data['subdomain']}.unfuddle.com"
+    http.url_prefix = "#{protocol}://#{data['subdomain']}.unfuddle.com"
     http.basic_auth data['username'], data['password']
 
     # grab people data for matching author-id


### PR DESCRIPTION
This change allows the Unfuddle service hook to work with Unfuddle plans that don't support HTTPS. Per Unfuddle's [plans](http://unfuddle.com/about/tour/plans) and [API](http://unfuddle.com/docs/api#request_format) docs, HTTP access is supported as well.
