### PR TITLE
Add optional branch settings for travis

### DIFF
--- a/docs/travis
+++ b/docs/travis
@@ -13,6 +13,7 @@ Install Notes
       Optional steps:
       - Enter the username who the travis-token belongs to (defaults to the repository owner)
       - Enter the host of your Travis installation (defaults to http://travis-ci.org), the protocol-prefix is optional and defaults to "http://".
+      - Enter a space-separated list of branches to watch. Commits to other branches will not be notified to Travis. If no branches are specified, Travis will be notified of all commits.
 
   3.  Check the "Active" checkbox and click "Update Settings".
   4.  Click on the "Travis" service name and then click the "Test Hook" link.
@@ -28,5 +29,6 @@ data
   - token
   - user
   - domain
+  - branches
 
 The token has to belong to the user, of course.

--- a/services/travis.rb
+++ b/services/travis.rb
@@ -1,7 +1,11 @@
 class Service::Travis < Service
-  string :domain, :user, :token
+  string :domain, :user, :token, :branches
 
   def receive_push
+    branches = data['branches'].to_s.split(/\s+/)
+    ref = payload["ref"].to_s
+    return unless branches.empty? || branches.include?(ref.split("/").last)
+
     http.ssl[:verify] = false
     http.basic_auth user, token
     http_post travis_url, :payload => payload.to_json


### PR DESCRIPTION
Allowing to specify on for which branches travis should be notified.
All non-Ruby projects will get failing builds for branches which don't have .yml file present, due to travis defaults are focussed on Ruby.
Allowing to specify branches will avoid failing builds and automatic email notifications  (also default on Travis)
