### PR TITLE
Email: Fix alignment of changed paths.

### DIFF
--- a/services/email.rb
+++ b/services/email.rb
@@ -101,7 +101,7 @@ class Service::Email < Service
     modified = commit['modified'].map { |f| ['M', f] }
 
     changed_paths = (added + removed + modified).sort_by { |(char, file)| file }
-    changed_paths = changed_paths.collect { |entry| entry * ' ' }.join("\n  ")
+    changed_paths = changed_paths.collect { |entry| entry * ' ' }.join("\n    ")
 
     timestamp = Date.parse(commit['timestamp'])
 


### PR DESCRIPTION
The email service code was sending emails with the "changed paths" looking like this:

```
  Changed paths:
    M lib/grit/grit.rb
  M test/helper.rb
  M test/test_grit.rb
```

This patch makes it look like this:

```
  Changed paths:
    M lib/grit/grit.rb
    M test/helper.rb
    M test/test_grit.rb
```

-David
