### PR TITLE
campfire: allow configuring the sound to play

### DIFF
--- a/docs/campfire
+++ b/docs/campfire
@@ -17,6 +17,9 @@ Install Notes
 
   5. play_sound is a boolean flag indicating whether a sound should be played
 
+  6. sound is the sound that should be played if play_sound is
+     true. defaults to 'rimshot'
+
 
 Developer Notes
 ---------------
@@ -25,6 +28,7 @@ data
   - subdomain
   - token
   - room
+  - sound
   - master_only
   - play_sound
 

--- a/services/campfire.rb
+++ b/services/campfire.rb
@@ -5,7 +5,7 @@ class Service::Campfire < Service
 
   self.campfire_class = Tinder::Campfire
 
-  string :subdomain, :room, :token
+  string :subdomain, :room, :token, :sound
   boolean :master_only, :play_sound, :long_url
 
   default_events :push, :pull_request, :issues
@@ -36,13 +36,14 @@ class Service::Campfire < Service
     return if data['master_only'].to_i == 1 && respond_to?(:branch_name) && branch_name != 'master'
 
     play_sound = data['play_sound'].to_i == 1
+    sound = data['sound'].blank? ? 'rimshot' : data['sound']
 
     unless room = find_room
       raise_config_error 'No such campfire room'
     end
 
     Array(messages).each { |line| room.speak line }
-    room.play "rimshot" if play_sound && room.respond_to?(:play)
+    room.play sound if play_sound && room.respond_to?(:play)
   rescue OpenSSL::SSL::SSLError => boom
     raise_config_error "SSL Error: #{boom}"
   rescue Tinder::AuthenticationFailed => boom


### PR DESCRIPTION
I would have gotten rid of play_sound and just not played a sound when data['sound'] is blank, but I left it so that people don't suddenly stop getting rimshots. Not sure what goes on behind the scenes here...
