### PR TITLE
Remove @ name completion operator from Yammer hook as it does the wrong thing

### DIFF
--- a/services/yammer.rb
+++ b/services/yammer.rb
@@ -10,11 +10,11 @@ class Service::Yammer < Service
     if data['digest'] == '1'
       commit   = payload['commits'][-1]
       tiny_url = shorten_url("#{payload['repository']['url']}/commits/#{ref_name}")
-      statuses << "@#{commit['author']['name']} pushed #{payload['commits'].length}.  #{tiny_url} \##{repository}"
+      statuses << "#{commit['author']['name']} pushed #{payload['commits'].length}.  #{tiny_url} \##{repository}"
     else
       payload['commits'].each do |commit|
         tiny_url = shorten_url(commit['url'])
-        statuses << "#{commit['message']} (committer: @#{commit['author']['name']}) #{tiny_url} \##{repository}"
+        statuses << "#{commit['message']} (committer: #{commit['author']['name']}) #{tiny_url} \##{repository}"
       end
     end
 


### PR DESCRIPTION
Hi, I'd like to propose a small change to the Yammer hook. The hook prefixes the committer's full name with an @ sign in the posted message, in hopes that it will get hyperlinked to a Yammer user of the same name.

But what really happens is that Yammer looks for a user account with a matching _first_ name, and then expands that.

(note: I've inserted spaces between @ and names below so that GitHub won't try to autolink)

So, for instance, let's say I (Brian Sharon) commit. The hook posts "... (committer: @ Brian Sharon)" to Yammer. Yammer receives that and expands @ Brian to another developer on our team, so that it ends up in the stream as "...  (committer: @ Brian Terry Sharon)".

Even better is when Brian Terry commits and it shows up as " (committer: @ Brian Terry Terry)".

So it's just busted. I took a quick look at the Yammer docs but didn't see an easy way to fix this.
