### PR TITLE
Updated TP hook to play nicely with latest REST API changes

### DIFF
--- a/services/target_process.rb
+++ b/services/target_process.rb
@@ -47,7 +47,7 @@ private
     # get the user's id
     res = http_get "api/v1/Users", {:where => "(Email eq '%s')" % author}
     valid_response?(res)
-    author_id = begin Hash.from_xml(res.body)['Items']['User']['Id'] rescue nil end
+    author_id = begin Hash.from_xml(res.body)['Users']['User']['Id'] rescue nil end
     return if author_id.nil?
     # get Context data for our project
     res = http_get "api/v1/Context", :ids => @project_id
@@ -64,7 +64,7 @@ private
     res = http_get "api/v1/Processes/%s/EntityStates" % [context_data['Context']['Processes']['ProcessInfo']['Id']],
         {:where => "(Name eq '%s') and (EntityType.Name eq '%s')" % [command, entity_type], :acid => acid}
     valid_response?(res)
-    new_state = begin Hash.from_xml(res.body)['Items']['EntityState']['Id'] rescue nil end
+    new_state = begin Hash.from_xml(res.body)['EntityStates']['EntityState']['Id'] rescue nil end
     # Make it happen
     http.headers['Content-Type'] = 'application/json'
     commit_message = "#{commit_message}<br />Commit: #{commit_url}"

--- a/test/target_process_test.rb
+++ b/test/target_process_test.rb
@@ -16,14 +16,14 @@ class TargetProcessTest < Service::TestCase
     @stubs.get "/tp/api/v1/Users?where=(Email%20eq%20'jonnyfunfun@gmail.com')" do |env|
       assert_equal basic_auth('uz0r', 'p455w0rd'), env[:request_headers]['authorization']
       assert_equal "(Email eq 'jonnyfunfun@gmail.com')", env[:params]['where']
-      [200, {}, '<Items><User Id="31337"><Email>jonnyfunfun@gmail.com</Email></User><User Id="3"><Email>foobar@snafu.com</Email></User></Items>']
+      [200, {}, '<Users><User Id="31337"><Email>jonnyfunfun@gmail.com</Email></User><User Id="3"><Email>foobar@snafu.com</Email></User></Users>']
     end
 
     @stubs.get "/tp/api/v1/Processes/OMGWTFBBQ/EntityStates?where(Name%20eq%20'fubar')%20and%20(EntityType.Name%20eq%20'Bug')" do |env|
       assert_equal 'ZOMG', env[:params]['acid']
       assert_equal "(Name eq 'fubar') and (EntityType.Name eq 'Bug')", env[:params]['where']
       assert_equal basic_auth('uz0r', 'p455w0rd'), env[:request_headers]['authorization']
-      [200, {}, '<Items><EntityState Name="fubar" Id="21"/><EntityState Name="not me" Id="0"/></Items>']
+      [200, {}, '<EntityStates><EntityState Name="fubar" Id="21"/><EntityState Name="not me" Id="0"/></EntityStates>']
     end
 
     @stubs.get "/tp/api/v1/Assignables/1783?acid=ZOMG&include=%5BEntityType%5D" do |env|


### PR DESCRIPTION
The REST API in TargetProcess has changed.  In particular, when selecting a collection of entities they were previously returned in a node called _Items_.  This has changed so that they are returned in a node whose name is the plural of the entity type you're collecting.  This updates the hook to play nicely with these changes.
