### PR TITLE
Expanded Fogbugz hook regular expression

### DIFF
--- a/services/fog_bugz.rb
+++ b/services/fog_bugz.rb
@@ -22,7 +22,7 @@ class Service::FogBugz < Service
       bug_list = []
       message.split("\n").each do |line|
         # match variants of bugids or cases
-        if (line =~ /\s*(?:Bug[zs]*\s*IDs*\s*|Case[s]*)[#:; ]+((\d+[ ,:;#]*)+)/i)
+        if (line =~ /\s*(?:Bug[zs]*\s*(IDs*)?\s*|Case[s]*|Ticket[s]*)[#:; ]+((\d+[ ,:;#]*)+)/i)
           bug_list << $1.to_i
         end
       end


### PR DESCRIPTION
Expanded regular expression to include some additional variations that I think are useful.

My team constantly wants to write "bug 123" or "ticket 123" in the commit message. Unfortunately the old expression would only match "bug[zs]id[s] 123" or "case[s] 123". I made the ID portion optional and added "Ticket[s]" as well. Would love for this change to be applied to the service hook.
