### PR TITLE
Add branch regex to irc client

### DIFF
--- a/services/irc.rb
+++ b/services/irc.rb
@@ -121,6 +121,7 @@ class Service::IRC < Service
   
   def branch_name_matches?
     return true if data['branch_regexes'].nil?
+    return true if data['branch_regexes'].strip == ""
     branch_regexes = data['branch_regexes'].split(',')
     branch_regexes.each do |regex|
       return true if Regexp.new(regex) =~ branch_name


### PR DESCRIPTION
Prior to this commit, the IRC service would dutifully notify you of
every push to every branch. This allows you to limit, via
comma-separated regexes, which branches will notify via IRC.

NOTE: It's possible that a `,` separated list of regexes could cause
problems if people want to use a `,` in the regex. If this is an issue, 
I'll add a field to specify the delimiter.
