### PR TITLE
Github-Serivce which alerts a URL when the repo visibility is changed from 'Private' to 'Public'

### DIFF
--- a/docs/public
+++ b/docs/public
@@ -4,9 +4,9 @@ Public
 Install Notes
 -------------
 
-1. `remote_url` Remote Web-Service Url which listens to `post` sent from github
-2. `auth_token` Authentication Token to be used by the POST URL
-3. `repo_name` Repo Name which this Public Hook is associated with
+1. `remote_url` (Required) Remote Web-Service Url which listens to `post` sent from github
+2. `auth_token` (Required) Authentication Token to be used by the POST URL
+3. `repo_name` (Required) Repo Name which this Public Hook is associated with
 4. `notify_email` (Optional) Email Address(1) to intimate that Public Event is generated
 
 Developer Notes

--- a/services/pubalert.rb
+++ b/services/pubalert.rb
@@ -31,7 +31,10 @@ class Service::PubAlert < Service
         raise_config_error
       end
     rescue URI::Error => e
-      raise_config_error "Not able to send a POST request to #{data['remote_url']}. Reason being:%s" % e.message
+      #Ideally this should be logged somewhere. Or the Error need to be
+      #raised as a config_error but since emailing the 'Public' event
+      #(if an email-address is specified) should also be done, this is supresessed.
+      #raise_config_error "Not able to send a POST request to #{data['remote_url']}. Reason being:%s" % e.message
     end
 
     notify_email = data['notify_email'].split(/[, ]/).compact.reject {|s| s.nil? or s.empty? }[0]

--- a/test/pubalert_test.rb
+++ b/test/pubalert_test.rb
@@ -1,65 +1,5 @@
 require File.expand_path('../helper', __FILE__)
 
-class PubAlertInValidEmailTests < Service::TestCase
-  def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-  end
-
-  def test_public_alert_with_invalid_notify_email_hook_param
-    callback_for_public_event = 'handle_public_event/'
-    data = {'remote_url'   => "http://127.0.0.1:8000/#{callback_for_public_event}",
-            'auth_token' => 'at',
-            'repo_name' => 'r',
-            'notify_email' => 'invalidemailaddress'}
-    svc = service :public, data
-
-    @stubs.post "/#{callback_for_public_event}" do |env|
-      assert_equal 'public', env[:request_headers]['x-github-event']
-      assert_match /form/, env[:request_headers]['content-type']
-      assert_equal '127.0.0.1', env[:url].host
-      assert_nil env[:request_headers]['X-Hub-Signature']
-      [200, {}, '']
-    end
-
-    exception = assert_raise(Service::ConfigurationError) { svc.receive_public}
-    assert(exception.message.include? "Not able to shoot email to #{data['notify_email']}")
-    assert_equal svc.messages.size, 0
-  end
-
-  def service(*args)
-    svc = super Service::PubAlert, *args
-    def svc.messages
-      @messages ||= []
-    end
-
-    def svc.notify_event(address, repo_name)
-      my = self
-      Mail.defaults do
-        delivery_method :smtp, { :address   => my.email_config['address'],
-                             :port      => my.email_config['port'],
-                             :domain    => my.email_config['domain'],
-                             :user_name => my.email_config['user_name'],
-                             :password  => my.email_config['password'],
-                             :authentication => my.email_config['authentication'],
-                             :enable_starttls_auto => my.email_config['enable_starttls_auto']}
-
-      end
-      mail_message = Mail.deliver do
-        to       address
-        from     "GitHub <noreply@github.com>"
-        reply_to "GitHub <noreply@github.com>"
-        subject  "#{repo_name} is open-sourced."
-        text_part do
-          content_type 'text/plain; charset=UTF-8'
-          body         "#{repo_name} is open-sourced."
-        end
-      end
-      messages << mail_message
-    end
-    svc
-  end
-end
-
 class PubAlertTest < Service::TestCase
   def setup
     @stubs = Faraday::Adapter::Test::Stubs.new
@@ -79,13 +19,16 @@ class PubAlertTest < Service::TestCase
   end
 
   def test_empty_repo_name_hook_param
-    data = {'remote_url' => 'a', 'auth_token' => 'b'}
+    data = {'remote_url' => 'a',
+            'auth_token' => 'b'}
     svc = service :public, data
     exception = assert_raise(Service::ConfigurationError) { svc.receive_public}
     assert_match /Missing 'repo_name'/, exception.message
   end
 
-  def test_public_alert_without_notify_email_hook_param
+
+-
+  def test_empty_notify_email_hook_param
     callback_for_public_event = 'handle_public_event/'
     data = {'remote_url'   => "http://127.0.0.1:8000/#{callback_for_public_event}",
             'auth_token' => 'at',
@@ -162,27 +105,10 @@ class PubAlertTest < Service::TestCase
     assert_equal msg['reply_to'], "GitHub <noreply@github.com>"
     assert_equal msg['subject'], "#{data['repo_name']} is open-sourced."
     assert_equal msg['body'], "#{data['repo_name']} is open-sourced."
+
+    # Anymore addresses ? ignored.
+    assert_nil svc.messages.shift
   end
-
-  #def test_public_alert_with_invalid_remote_url_hook_param
-  #  data = {'remote_url'   => "somedomain",
-  #          'auth_token' => 'at',
-  #          'repo_name' => 'r',
-  #          'notify_email' => ''}
-  #  svc = service :public, data
-
-  #  @stubs.post "/foo" do |env|
-  #    assert_equal 'public', env[:request_headers]['x-github-event']
-  #    assert_match /form/, env[:request_headers]['content-type']
-  #    assert_equal 'somedomain.com', env[:url].host
-  #    assert_nil env[:request_headers]['X-Hub-Signature']
-  #    [200, {}, '']
-  #  end
-
-  #  exception = assert_raise(URI::Error) { svc.receive_public}
-  #  assert(exception.message.include? "Not able to send a POST request to #{data['remote_url']}")
-  #  assert_equal svc.messages.size, 0
-  #end
 
   def service(*args)
     svc = super Service::PubAlert, *args


### PR DESCRIPTION
When a repo visibility is changed from `Private` to `Public`, this Service Hook fires a POST request to a `configured URL`. Additionally if a email address is configured, an email will be sent mentioning the action made. Usecases for this include:
1. Shooting an email about the `Open-Sourced` event to a common mailing list.
2. If a _enterprise_ repo is made `Public` _accidentally_, a web-service can be setup which uses Github API to flip the repo visibility back to `Private`.
