### PR TITLE
Include GitHub events in the new Basecamp timeline

### DIFF
--- a/docs/basecamp
+++ b/docs/basecamp
@@ -4,24 +4,18 @@ Basecamp
 Install Notes
 -------------
 
-  1. url should be your Basecamp url
-  2. username should be the username or API token of the user that you want to use to post messages into your Basecamp - you can setup a user just for this purpose
-  3. password should be the password of the user that you want to use to post the messages.  If username is an API token, set password to 'x'.
-  4. project should be the name of the project that you want to post the message into (not the id)
-  5. category should be the name of the category that you want to post the message using (not the id)
-  6. ssl should be enabled for accounts that need SSL.
+  1. project_url is the URL of your Basecamp project: https://basecamp.com/1234/projects/5678
+  2. email_address is the email you sign in to Basecamp with. This person must have access to the project. To add events on behalf of other people, make the person an admin on the project.
+  3. password is the password you sign in to Basecamp with.
 
 
 Developer Notes
 ---------------
 
 data
-  - url
-  - username
+  - project_url
+  - email_address
   - password
-  - project
-  - category
-  - ssl
 
 payload
   - refer to docs/github_payload

--- a/docs/basecamp_classic
+++ b/docs/basecamp_classic
@@ -1,0 +1,27 @@
+Basecamp Classic
+================
+
+Install Notes
+-------------
+
+  1. url should be your Basecamp Classic url
+  2. username should be the username or API token of the user that you want to use to post messages into your Basecamp - you can setup a user just for this purpose
+  3. password should be the password of the user that you want to use to post the messages.  If username is an API token, set password to 'x'.
+  4. project should be the name of the project that you want to post the message into (not the id)
+  5. category should be the name of the category that you want to post the message using (not the id)
+  6. ssl should be enabled for accounts that need SSL.
+
+
+Developer Notes
+---------------
+
+data
+  - url
+  - username
+  - password
+  - project
+  - category
+  - ssl
+
+payload
+  - refer to docs/github_payload

--- a/services/basecamp.rb
+++ b/services/basecamp.rb
@@ -35,7 +35,7 @@ class Service::Basecamp < Service
   private
 
   def create_event(action, message, url, author_email = nil)
-    http_post_event :service => 'github',
+    http_post_event :service => 'GitHub',
       :creator_email_address => author_email,
       :description => action,
       :title => message,

--- a/services/basecamp_classic.rb
+++ b/services/basecamp_classic.rb
@@ -1,0 +1,147 @@
+class Service::BasecampClassic < Service
+  string      :url, :project, :category, :username
+  password    :password
+  boolean     :ssl
+  white_list  :url, :project, :category, :username
+
+
+  def hook_name
+    'basecamp'
+  end
+
+  def receive_push
+    raise_config_error "Invalid basecamp domain" if basecamp_domain.nil?
+
+    repository      = payload['repository']['name']
+    name_with_owner = File.join(payload['repository']['owner']['name'], repository)
+    branch          = ref_name
+
+    commits = payload['commits'].reject { |commit| commit['message'].to_s.strip == '' }
+    return if commits.empty?
+
+    ::Basecamp.establish_connection! basecamp_domain,
+      data['username'], data['password'], data['ssl'].to_i == 1
+
+    commits.each do |commit|
+      gitsha        = commit['id']
+      short_git_sha = gitsha[0..5]
+      timestamp     = Date.parse(commit['timestamp'])
+
+      added         = commit['added'].map    { |f| ['A', f] }
+      removed       = commit['removed'].map  { |f| ['R', f] }
+      modified      = commit['modified'].map { |f| ['M', f] }
+      changed_paths = (added + removed + modified).sort_by { |(char, file)| file }
+      changed_paths = changed_paths.collect { |entry| entry * ' ' }.join("\n  ")
+
+      # Shorten the elements of the subject
+      commit_title = commit['message'][/^([^\n]+)/, 1]
+      if commit_title.length > 50
+        commit_title = commit_title.slice(0,50) << '...'
+      end
+
+      title = "Commit on #{name_with_owner}: #{short_git_sha}: #{commit_title}"
+
+      body = <<-EOH
+*Author:* #{commit['author']['name']} <#{commit['author']['email']}>
+*Commit:* <a href="#{commit['url']}">#{gitsha}</a>
+*Date:*   #{timestamp} (#{timestamp.strftime('%a, %d %b %Y')})
+*Branch:* #{branch}
+*Home:*   #{payload['repository']['url']}
+
+h2. Log Message
+
+<pre>#{commit['message']}</pre>
+EOH
+
+      if changed_paths.size > 0
+        body << <<-EOH
+
+h2. Changed paths
+
+<pre>  #{changed_paths}</pre>
+EOH
+      end
+
+      post_message :title => title, :body => body
+    end
+
+  rescue SocketError => boom
+    if boom.to_s =~ /getaddrinfo: Name or service not known/
+      raise_config_error "Invalid basecamp domain name"
+    else
+      raise
+    end
+  rescue ActiveResource::UnauthorizedAccess => boom
+    raise_config_error "Unauthorized. Verify the project URL and credentials."
+  rescue ActiveResource::ForbiddenAccess => boom
+    raise_config_error boom.to_s
+  rescue ActiveResource::Redirection => boom
+    raise_config_error "Invalid project URL: #{boom}"
+  rescue RuntimeError => boom
+    if boom.to_s =~ /\((?:403|401|422)\)/
+      raise_config_error "Invalid credentials: #{boom}"
+    elsif boom.to_s =~ /\((?:404|301)\)/
+      raise_config_error "Invalid project URL: #{boom}"
+    elsif boom.to_s == 'Unprocessable Entity (422)'
+      # do nothing
+    else
+      raise
+    end
+  end
+
+  attr_writer :basecamp
+  attr_writer :project_id
+  attr_writer :category_id
+
+  def basecamp_domain
+    @basecamp_domain ||= Addressable::URI.parse(data['url'].to_s).host
+  rescue Addressable::URI::InvalidURIError
+  end
+
+  def build_message(options = {})
+    m = ::Basecamp::Message.new :project_id => project_id
+    m.category_id = category_id
+    options.each do |key, value|
+      m.send "#{key}=", value
+    end
+    m
+  end
+
+  def post_message(options = {})
+    build_message(options).save
+  end
+
+  def all_projects
+    Array(::Basecamp::Project.all)
+  end
+
+  def all_categories
+    Array(::Basecamp::Category.post_categories(project_id))
+  end
+
+  def project_id
+    @project_id ||= begin
+      name = data['project'].to_s
+      name.downcase!
+      projects = all_projects.select { |p| p.name.downcase == name }
+      case projects.size
+      when 1 then projects.first.id
+      when 0 then raise_config_error("Invalid Project: #{name.downcase}")
+      else raise_config_error("Multiple projects named: #{name.downcase}")
+      end
+    end
+  end
+
+  def category_id
+    @category_id ||= begin
+      name = data['category'].to_s
+      name.downcase!
+      categories = all_categories.select { |c| c.name.downcase == name }
+      case categories.size
+      when 1 then categories.first.id
+      when 0 then raise_config_error("Invalid Category: #{name.downcase}")
+      else raise_config_error("Multiple categories named: #{name.downcase}")
+      end
+    end
+  end
+end

--- a/test/basecamp_classic_test.rb
+++ b/test/basecamp_classic_test.rb
@@ -1,0 +1,30 @@
+require File.expand_path('../helper', __FILE__)
+
+class BasecampClassicTest < Service::TestCase
+  def test_receives_push
+    svc = service :push, {'url' => 'https://foo.com', 'username' => 'monkey', 'password' => 'abc'}, payload
+    svc.receive
+
+    assert msg = svc.messages.shift
+    assert_equal 2, msg.category_id
+    assert msg.title.present?
+    assert msg.body.present?
+  end
+
+  def service(*args)
+    svc = super Service::BasecampClassic, *args
+
+    svc.project_id  = 1
+    svc.category_id = 2
+
+    def svc.messages
+      @messages ||= []
+    end
+
+    def svc.post_message(options = {})
+      messages << build_message(options)
+    end
+
+    svc
+  end
+end

--- a/test/basecamp_test.rb
+++ b/test/basecamp_test.rb
@@ -1,30 +1,87 @@
 require File.expand_path('../helper', __FILE__)
 
 class BasecampTest < Service::TestCase
-  def test_receives_push
-    svc = service :push, {'url' => 'https://foo.com', 'username' => 'monkey', 'password' => 'abc'}, payload
-    svc.receive
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
 
-    assert msg = svc.messages.shift
-    assert_equal 2, msg.category_id
-    assert msg.title.present?
-    assert msg.body.present?
+    @options = {
+      'project_url'   => 'https://basecamp.com/123/projects/456',
+      'email_address' => 'a@b.com',
+      'password'      => 'secret' }
+  end
+
+  def test_push
+    @stubs.post '/123/api/v1/projects/456/events.json' do |env|
+      assert_equal 'https', env[:url].scheme
+      assert_equal 'basecamp.com', env[:url].host
+
+      assert_equal 'Basic YUBiLmNvbTpzZWNyZXQ=', env[:request_headers]['Authorization']
+
+      assert_match 'GitHub', env[:request_headers]['User-Agent']
+      assert_equal 'application/json', env[:request_headers]['Content-Type']
+      assert_equal 'application/json', env[:request_headers]['Accept']
+
+      expected = {
+        'service' => 'github',
+        'creator_email_address' => 'tom@mojombo.com',
+        'description' => 'committed',
+        'title' => 'pushed 3 new commits to master',
+        'url' => 'http://github.com/mojombo/grit/compare/4c8124f...a47fd41' }
+      assert_equal expected, JSON.parse(env[:body])
+
+      [200, {}, '']
+    end
+
+    service(@options, payload).receive_push
+  end
+
+  def test_pull
+    @stubs.post '/123/api/v1/projects/456/events.json' do |env|
+      expected = {
+        'service' => 'github',
+        'creator_email_address' => nil,
+        'description' => 'opened a pull request',
+        'title' => 'booya (master..feature)',
+        'url' => 'html_url' }
+      assert_equal expected, JSON.parse(env[:body])
+
+      [200, {}, '']
+    end
+
+    service(:pull_request, @options, pull_payload).receive_pull_request
+  end
+
+  def test_issues
+    @stubs.post '/123/api/v1/projects/456/events.json' do |env|
+      expected = {
+        'service' => 'github',
+        'creator_email_address' => nil,
+        'description' => 'opened an issue',
+        'title' => 'booya',
+        'url' => 'html_url' }
+      assert_equal expected, JSON.parse(env[:body])
+
+      [200, {}, '']
+    end
+
+    service(:issues, @options, issues_payload).receive_issues
   end
 
   def service(*args)
-    svc = super Service::Basecamp, *args
+    super Service::Basecamp, *args
+  end
 
-    svc.project_id  = 1
-    svc.category_id = 2
-
-    def svc.messages
-      @messages ||= []
+  # No html_url in default payload
+  def pull_payload
+    super.tap do |payload|
+      payload['pull_request']['html_url'] = 'html_url'
     end
+  end
 
-    def svc.post_message(options = {})
-      messages << build_message(options)
+  # No html_url in default payload
+  def issues_payload
+    super.tap do |payload|
+      payload['issue']['html_url'] = 'html_url'
     end
-
-    svc
   end
 end


### PR DESCRIPTION
Rather than spamming tons of Basecamp messages, this adds GitHub events directly to a project's timeline.

Using HTTP Basic until it's easier to grab an OAuth 2 token.

Renames the old Basecamp hook to Basecamp Classic, but keeps the same internal names for back compat.
