### PR TITLE
Added Apoio service

### DIFF
--- a/docs/apoio
+++ b/docs/apoio
@@ -6,14 +6,14 @@ Install Notes
 
   1. Subdomain is your Apoio subdomain ('http://subdomain.apo.io')
 
-  2. Token is your Apoio Github token. You can get it from your profile.
+  2. Token is your Apoio API token.
 
 Developer Notes
 ---------------
 
 data
   - subdomain
-  - github_token
+  - token
 
 payload
   - refer to docs/github_payload

--- a/services/apoio.rb
+++ b/services/apoio.rb
@@ -1,10 +1,10 @@
 require 'uri'
 class Service::Apoio < Service
   default_events :issues
-  string   :subdomain, :github_token
+  string   :subdomain, :token
 
   def invalid_request?
-   data['github_token'].to_s.empty? or
+   data['token'].to_s.empty? or
    data['subdomain'].to_s.empty?
   end
 
@@ -25,7 +25,7 @@ class Service::Apoio < Service
 
     http.headers['Content-Type'] = 'application/json'
     http.headers['Accept'] = 'application/json'
-    http.headers['X-Github-Token'] = data['github_token']
+    http.headers['X-Api-Token'] = data['token']
 
     url = service_url(data['subdomain'])
     res = http_post(url, { :payload  => payload }.to_json)

--- a/test/apoio_test.rb
+++ b/test/apoio_test.rb
@@ -8,12 +8,12 @@ class ApoioTest < Service::TestCase
   def test_push
     @stubs.post "/service/github" do |env|
       assert_equal 'test.apo.io', env[:url].host
-      assert_equal "my123token", env[:request_headers]["X-Github-Token"]
+      assert_equal "my123token", env[:request_headers]["X-Api-Token"]
       [200, {}, '']
     end
 
     svc = service(
-      {'subdomain' => 'test', 'github_token' => 'my123token' },
+      {'subdomain' => 'test', 'token' => 'my123token' },
       payload)
     svc.receive_issues
   end


### PR DESCRIPTION
This service listens to `issues` events and posts it to the Apoio API.

Tests are included.
