### PR TITLE
Send Basecamp a GitHub logo for the timeline events

### DIFF
--- a/services/basecamp.rb
+++ b/services/basecamp.rb
@@ -1,4 +1,7 @@
 class Service::Basecamp < Service
+  SERVICE_NAME = 'GitHub'
+  LOGO_URL     = 'https://assets.github.com/images/modules/about_page/octocat.png'
+
   string          :project_url, :email_address
   password        :password
   white_list      :project_url, :email_address
@@ -31,7 +34,8 @@ class Service::Basecamp < Service
   private
 
   def create_event(action, message, url, author_email = nil)
-    http_post_event :service => 'GitHub',
+    http_post_event :service => SERVICE_NAME,
+      :logo_url => LOGO_URL,
       :creator_email_address => author_email,
       :description => action,
       :title => message,

--- a/test/basecamp_test.rb
+++ b/test/basecamp_test.rb
@@ -22,7 +22,8 @@ class BasecampTest < Service::TestCase
       assert_equal 'application/json', env[:request_headers]['Accept']
 
       expected = {
-        'service' => 'GitHub',
+        'service' => Service::Basecamp::SERVICE_NAME,
+        'logo_url' => Service::Basecamp::LOGO_URL,
         'creator_email_address' => 'tom@mojombo.com',
         'description' => 'committed',
         'title' => 'pushed 3 new commits to master',
@@ -38,7 +39,8 @@ class BasecampTest < Service::TestCase
   def test_pull
     @stubs.post '/123/api/v1/projects/456/events.json' do |env|
       expected = {
-        'service' => 'GitHub',
+        'service' => Service::Basecamp::SERVICE_NAME,
+        'logo_url' => Service::Basecamp::LOGO_URL,
         'creator_email_address' => nil,
         'description' => 'opened a pull request',
         'title' => 'booya (master..feature)',
@@ -54,7 +56,8 @@ class BasecampTest < Service::TestCase
   def test_issues
     @stubs.post '/123/api/v1/projects/456/events.json' do |env|
       expected = {
-        'service' => 'GitHub',
+        'service' => Service::Basecamp::SERVICE_NAME,
+        'logo_url' => Service::Basecamp::LOGO_URL,
         'creator_email_address' => nil,
         'description' => 'opened an issue',
         'title' => 'booya',


### PR DESCRIPTION
Adding :octocat: to Basecamp timeline events
