### PR TITLE
Add a branch filter on ShiningPanda hook

### DIFF
--- a/docs/shiningpanda
+++ b/docs/shiningpanda
@@ -13,7 +13,8 @@ Install Notes
   1. Workspace - This your workspace key. For instance if your Jenkins URL is https://jenkins.shiningpanda.com/shiningpanda.org, then your workspace key is "shiningpanda.org".
   2. Job - This is the name of the job you want to trigger upon commit. For instance if the URL of your job in Jenkins is https://jenkins.shiningpanda.com/shiningpanda.org/job/selenose/, then your job name is selenose.
   3. Token - This is the value of the "Authentication Token" field of the "Trigger builds remotely (e.g., from scripts)" option in the "Build Triggers" section of your job configuration.
-  4. Parameters (optional) - If your job takes parameters, this is the query string built from the parameters and their value (for instance "arg1=foo&arg2=bar"). All parameters have to be properly URL-escaped.
+  4. Branches (optional) - This is a space-separated list of branches to listen for commits on. Commits to other branches will not trigger your job. If no branches are specified, jobs are triggered for all commits.
+  5. Parameters (optional) - If your job takes parameters, this is the query string built from the parameters and their value (for instance "arg1=foo&arg2=bar"). All parameters have to be properly URL-escaped.
 
 Developer Notes
 ---------------
@@ -22,6 +23,7 @@ data
   - workspace
   - job
   - token
+  - branches (optional)
   - parameters (optional)
 
 payload

--- a/services/shiningpanda.rb
+++ b/services/shiningpanda.rb
@@ -1,5 +1,5 @@
 class Service::ShiningPanda < Service
-  string :workspace, :job, :token, :parameters
+  string :workspace, :job, :token, :branches, :parameters
 
   def receive_push
     if workspace.empty?
@@ -17,24 +17,27 @@ class Service::ShiningPanda < Service
     if query.has_key?('cause')
       raise_config_error "Illegal parameter: cause"
     end
-    Rack::Utils.parse_query(data['parameters']).each do |key, values|
-      if !values.is_a?(String) and values.length > 1
-        raise_config_error "Only one parameter value allowed for " + key
+    branch = payload['ref'].to_s.split('/').last
+    if branches.empty? || branches.include?(branch)
+      Rack::Utils.parse_query(data['parameters']).each do |key, values|
+        if !values.is_a?(String) and values.length > 1
+          raise_config_error "Only one parameter value allowed for " + key
+        end
       end
+      query[:token] = token
+      query[:cause] = "Triggered by a push of #{payload['pusher']['name']} to #{branch} (commit: #{payload['after']})"
+      http_post url, query
     end
-    query[:token] = token
-    query[:cause] = "Triggered by a push of #{payload['pusher']['name']} (commit: #{payload['after']})"
-    http_post url, query
   end
 
   def cleanup(key)
     ( data.has_key?(key) and data[key] != nil ) ? data[key] : ''
   end
-  
+
   def workspace
     @workspace ||= cleanup('workspace').strip
   end
-    
+
   def job
     @job ||= cleanup('job').strip
   end
@@ -42,17 +45,21 @@ class Service::ShiningPanda < Service
   def token
     @token ||= cleanup('token').strip
   end
-  
+
+  def branches
+    @branches ||= cleanup('branches').strip.split(/\s+/)
+  end
+
   def parameters
     @parameters ||= Rack::Utils.parse_nested_query(cleanup('parameters'))
   end
-  
+
   def query
     @query ||= parameters.clone
   end
-  
+
   def url
     @url ||= "https://jenkins.shiningpanda.com/#{workspace}/job/#{job}/#{parameters.empty? ? 'build' : 'buildWithParameters'}"
   end
-  
+
 end

--- a/test/shiningpanda_test.rb
+++ b/test/shiningpanda_test.rb
@@ -9,7 +9,7 @@ class ShiningPandaTest < Service::TestCase
     @stubs.post '/shiningpanda.org/job/pygments/build' do |env|
       form = Rack::Utils.parse_query(env[:body])
       assert_equal 'PWFm8c2T', form['token']
-      assert_equal 'Triggered by a push of omansion (commit: 83d9205e73c25092ce7cb7ce530d2414e6d068cb)', form['cause']
+      assert_equal 'Triggered by a push of omansion to master (commit: 83d9205e73c25092ce7cb7ce530d2414e6d068cb)', form['cause']
     end
     svc = service(data, payload)
     svc.receive_push
@@ -19,13 +19,57 @@ class ShiningPandaTest < Service::TestCase
     @stubs.post '/shiningpanda.org/job/pygments/buildWithParameters' do |env|
       form = Rack::Utils.parse_query(env[:body])
       assert_equal 'PWFm8c2T', form['token']
-      assert_equal 'Triggered by a push of omansion (commit: 83d9205e73c25092ce7cb7ce530d2414e6d068cb)', form['cause']
+      assert_equal 'Triggered by a push of omansion to master (commit: 83d9205e73c25092ce7cb7ce530d2414e6d068cb)', form['cause']
       assert_equal 'bar', form['foo']
     end
     svc = service(data.merge({'parameters' => 'foo=bar'}), payload)
     svc.receive_push
   end
-  
+
+  def test_receive_push_branch_match
+    @stubs.post '/shiningpanda.org/job/pygments/build' do |env|
+      form = Rack::Utils.parse_query(env[:body])
+      assert_equal 'PWFm8c2T', form['token']
+      assert_equal 'Triggered by a push of omansion to dev (commit: 83d9205e73c25092ce7cb7ce530d2414e6d068cb)', form['cause']
+    end
+    svc = service(data.merge({'branches' => 'dev'}), payload.merge({'ref' => 'refs/head/dev'}))
+    svc.receive_push
+  end
+
+  def test_receive_push_branches_match
+    @stubs.post '/shiningpanda.org/job/pygments/build' do |env|
+      form = Rack::Utils.parse_query(env[:body])
+      assert_equal 'PWFm8c2T', form['token']
+      assert_equal 'Triggered by a push of omansion to master (commit: 83d9205e73c25092ce7cb7ce530d2414e6d068cb)', form['cause']
+    end
+    svc = service(data.merge({'branches' => 'master dev'}), payload)
+    svc.receive_push
+  end
+
+  def test_receive_push_branch_mismatch
+    @stubs.post('/shiningpanda.org/job/pygments/build')
+    svc = service(data.merge({'branches' => 'dev'}), payload)
+    svc.receive_push
+    begin
+      @stubs.verify_stubbed_calls
+    rescue RuntimeError
+    else
+      assert_true false
+    end
+  end
+
+  def test_receive_push_branch_mismatch
+    @stubs.post('/shiningpanda.org/job/pygments/build')
+    svc = service(data.merge({'branches' => 'foo bar baz qux'}), payload)
+    svc.receive_push
+    begin
+      @stubs.verify_stubbed_calls
+    rescue RuntimeError
+    else
+      assert_true false
+    end
+  end
+
   def test_workspace_missing
     svc = service({ 'job' => 'pygments', 'token' => 'PWFm8c2T' }, payload)
     assert_raise Service::ConfigurationError do
@@ -46,7 +90,7 @@ class ShiningPandaTest < Service::TestCase
       svc.receive_push
     end
   end
-  
+
   def test_job_missing
     svc = service({ 'workspace' => 'shiningpanda.org', 'token' => 'PWFm8c2T' }, payload)
     assert_raise Service::ConfigurationError do
@@ -60,14 +104,14 @@ class ShiningPandaTest < Service::TestCase
       svc.receive_push
     end
   end
-  
+
   def test_job_blank
     svc = service(data.merge({'job' => ''}), payload)
     assert_raise Service::ConfigurationError do
       svc.receive_push
     end
   end
-  
+
   def test_token_missing
     svc = service({ 'workspace' => 'shiningpanda.org', 'job' => 'pygments' }, payload)
     assert_raise Service::ConfigurationError do
@@ -81,14 +125,14 @@ class ShiningPandaTest < Service::TestCase
       svc.receive_push
     end
   end
-  
+
   def test_token_blank
     svc = service(data.merge({'token' => ''}), payload)
     assert_raise Service::ConfigurationError do
       svc.receive_push
     end
   end
-  
+
   def test_url_without_parameters
     svc = service(data, payload)
     assert_equal "https://jenkins.shiningpanda.com/shiningpanda.org/job/pygments/build", svc.url
@@ -98,17 +142,17 @@ class ShiningPandaTest < Service::TestCase
     svc = service(data.merge({'parameters' => nil}), payload)
     assert_equal "https://jenkins.shiningpanda.com/shiningpanda.org/job/pygments/build", svc.url
   end
-  
+
   def test_url_blank_parameters
     svc = service(data.merge({'parameters' => ''}), payload)
     assert_equal "https://jenkins.shiningpanda.com/shiningpanda.org/job/pygments/build", svc.url
   end
-  
+
   def test_url_with_parameters
     svc = service(data.merge({'parameters' => 'foo=bar'}), payload)
     assert_equal "https://jenkins.shiningpanda.com/shiningpanda.org/job/pygments/buildWithParameters", svc.url
   end
-  
+
   def test_url_strip_workspace
     svc = service(data.merge({'workspace' => ' shiningpanda.org '}), payload)
     assert_equal "https://jenkins.shiningpanda.com/shiningpanda.org/job/pygments/build", svc.url
@@ -133,7 +177,7 @@ class ShiningPandaTest < Service::TestCase
       svc.receive_push
     end
   end
-  
+
   def service(*args)
     super Service::ShiningPanda, *args
   end
@@ -141,12 +185,13 @@ class ShiningPandaTest < Service::TestCase
   def payload
     {
       'after'  => '83d9205e73c25092ce7cb7ce530d2414e6d068cb',
+      'ref' => 'refs/heads/master',
       'pusher' => {
         'name'   => 'omansion',
       }
     }
   end
-  
+
   def data
     {
       'workspace' => 'shiningpanda.org',


### PR DESCRIPTION
Hi,

One of the ShiningPanda hook user (jzempel) sent a pull request on our shiningpanda/github-services repository to be able to filter on branches before notifying ShiningPanda.

This is an interesting feature, so we'd like to propagate it to our hook in production.

Thanks! 
