### PR TITLE
cia: add repo name as module

### DIFF
--- a/services/cia.rb
+++ b/services/cia.rb
@@ -18,6 +18,8 @@ class Service::CIA < Service
         ref_name
       end
 
+    module_name = payload['repository']['name']
+
     commits = payload['commits']
 
     if commits.size > 5
@@ -72,6 +74,7 @@ class Service::CIA < Service
         <source>
           <project>#{repository}</project>
           <branch>#{branch}</branch>
+          <module>#{module_name}</module>
         </source>
         <timestamp>#{timestamp}</timestamp>
         <body>


### PR DESCRIPTION
Cia supports modules name. Setting the repo name as the module allow cia to understand that the repo is a module for a bigger project
