### PR TITLE
Update for acunote service hook documentation

### DIFF
--- a/docs/acunote
+++ b/docs/acunote
@@ -8,6 +8,7 @@ Install Notes
 -------------
 
   1. Token - GitHub Service Hook Token for your Acunote organization. Get it from "Edit Organization" > "Repositories" page in Acunote.
+  2. Don't forget to check "Active"
 
 
 Developer Notes


### PR DESCRIPTION
I've added a reminder that user must check "Active" box into install notes. Apparently most people forget to do that.
