### PR TITLE
Fix for TeamCity infinite loop

### DIFF
--- a/docs/teamcity
+++ b/docs/teamcity
@@ -18,9 +18,12 @@ Install Notes
   4.  "username" and "password" - username and password of a TeamCity user that can
       trigger a manual build of the TeamCity build configuration defined in "build_type_id"
 
-  5.  Since TeamCity uses BASIC authentication, it is highly recommended that the TeamCity server
-      use HTTPS/SSL to protect the password that is passed unencrypted over the internet.
+  5.  "branches" is an optional space-separated list of branches to watch commits for. 
+      Commits to other branches will be ignored. If no branches are specified, 
+      TeamCity will be notified of all commits.
 
+  6.  Since TeamCity uses BASIC authentication, it is highly recommended that the TeamCity server
+      use HTTPS/SSL to protect the password that is passed unencrypted over the internet.
 
 Developer Notes
 ---------------
@@ -30,6 +33,7 @@ data
   - build_type_id
   - username
   - password
-
+  - branches
+ 
 payload
   - unused by this service

--- a/services/teamcity.rb
+++ b/services/teamcity.rb
@@ -1,9 +1,13 @@
 class Service::TeamCity < Service
-  string   :base_url, :build_type_id, :username
+  string   :base_url, :build_type_id, :username, :branches
   password :password
-  white_list :base_url, :build_type_id, :username
+  white_list :base_url, :build_type_id, :username, :branches
 
   def receive_push
+    branches = data['branches'].to_s.split(/\s+/)
+    ref = payload["ref"].to_s
+    return unless branches.empty? || branches.include?(ref.split("/").last)
+
     # :(
     http.ssl[:verify] = false
 


### PR DESCRIPTION
It solves the problem described here:
http://devnet.jetbrains.net/message/5460892#5460892.  When you trigger
builds using webhook and have enabled VCS labeling, TeamCity goes into
infinite loop: it is notified on every push, every push triggers the
build, every build makes a tag and pushes it.
