### PR TITLE
Add generated at timestamp metadata to services

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,8 +22,12 @@ namespace :services do
         :title => svc.title, :schema => svc.schema}
     end
     services.sort! { |x, y| x[:name] <=> y[:name] }
+    data = {
+      :metadata => { :generated_at => Time.now.utc },
+      :services => services
+    }
     File.open file, 'w' do |io|
-      io << Yajl.dump(services, :pretty => true)
+      io << Yajl.dump(data, :pretty => true)
     end
   end
 end


### PR DESCRIPTION
To be able to add caching to the /hooks web service, we need to know when the services.json file was created.
