### PR TITLE
Add the ability to send an MQTT update as a retained publication in service hook

### DIFF
--- a/docs/mqttpub
+++ b/docs/mqttpub
@@ -12,7 +12,8 @@ Install Notes
 4. OPTIONAL. 'clientid' is the unique client ID which publishes the payload message (default is a prefixed epoc time long, e.g. "github_1336363787").
 5. OPTIONAL. 'user' is the v3.1 username (default is none).
 6. OPTIONAL. 'pass' is the v3.1 password (default is none).
-7. The payload of the message is JSON received from Github (refer to docs/github_payload).
-8. ruby-mqtt only supports QoS 0.
-9. For testing, you can use mqtt.io as your web MQTT client.  broker: q.m2m.io, port: 1883, clientid: {github_username}.  You will "Subscribe to Topics": 'github/{github_username}/{repo_name}'.  Unauthenticated username/password sets default to the public channel!
+7. OPTIONAL. 'retain' specifies whether or not the publication should be retained as the last/most recent message for new subscribers.
+8. The payload of the message is JSON received from Github (refer to docs/github_payload).
+9. ruby-mqtt only supports QoS 0.
+10. For testing, you can use mqtt.io as your web MQTT client.  broker: q.m2m.io, port: 1883, clientid: {github_username}.  You will "Subscribe to Topics": 'github/{github_username}/{repo_name}'.  Unauthenticated username/password sets default to the public channel!
 

--- a/services/mqtt.rb
+++ b/services/mqtt.rb
@@ -1,6 +1,9 @@
 class Service::MqttPub < Service
+  self.title = 'MQTT publish'
+  
   string   :broker, :port, :topic, :clientid, :user
   password :pass
+  boolean  :retain
 
   require 'mqtt'
 
@@ -59,7 +62,7 @@ class Service::MqttPub < Service
         :username => user,
         :password => pass
       ) do |client|
-          client.publish(data['topic'].to_s, payload.to_json)
+          client.publish(data['topic'].to_s, payload.to_json, retain=data['retain'])
           # Disconnect (don't send last will and testament)
           client.disconnect(false)
         end


### PR DESCRIPTION
This pull request adds an additional boolean to the MqttPub service hook which enables the message to be marked as retained, meaning that it will remain available to subscriber who arrive after the publication was sent. This also makes it useful for checking a specified MQTT topic for the last known commit.

It also changes the display label of the service hook from MqttPub to MQTT Publish. The service hook code file itself remains named mqtt.rb.

No change is strictly necessary to the test code for the service hook - it will simply assume that the publication is non-retained.
