### PR TITLE
Adding a master_only option to the Yammer service

### DIFF
--- a/services/yammer.rb
+++ b/services/yammer.rb
@@ -1,9 +1,11 @@
 class Service::Yammer < Service
   string :group_id, :consumer_key, :consumer_secret,
     :access_token, :access_secret
-  boolean :digest
+  boolean :digest, :master_only
 
   def receive_push
+    return if data['master_only'].to_i == 1 && respond_to?(:branch_name) && branch_name != 'master'
+
     statuses   = [ ]
     repository = payload['repository']['name']
 


### PR DESCRIPTION
This pretty much clones the Campfire implementation. The diff of the tests looks weird because there was a bunch of setup code in the test_push method (formerly the only test), and I ended up moving that code down to the service method.
