### PR TITLE
Puppet Online Linter service hook

### DIFF
--- a/docs/puppetlinter
+++ b/docs/puppetlinter
@@ -1,0 +1,16 @@
+With the [Puppet Online Linter](http://www.puppetlinter.com) you can verify
+your Puppet manifests against the [Puppet Labs Style
+Guide](http://docs.puppetlabs.com/guides/style_guide.html) and have them
+validated for correct syntax with the Puppet parser. Any new commits generated
+in a project with this hook enabled will be sent to the linter for review. Only
+files with the Puppet `.pp` file extension will be linted. Reports will be
+emailed back to the author of the commit to the email address specified in the
+commit.
+
+The [public Web API](http://www.puppetlinter.com/api) can also be used to validate stand-alone transactions.
+
+Install Notes
+-------------
+
+1. None but any members of your project wants to opt out of receiving lintign
+reports then they can do so [here](http://www.puppetlinter.com/optout).

--- a/services/puppetlinter.rb
+++ b/services/puppetlinter.rb
@@ -1,0 +1,7 @@
+class Service::Puppetlinter < Service
+
+  def receive_push
+    url = URI.parse('http://www.puppetlinter.com/api/v1/hook')
+    http_post url, payload.to_json, 'Content-Type' => 'application/json'
+  end
+end

--- a/test/puppetlinter_test.rb
+++ b/test/puppetlinter_test.rb
@@ -1,0 +1,23 @@
+require File.expand_path('../helper', __FILE__)
+
+class PuppetlinterTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    url = '/api/v1/hook'
+    @stubs.post url do |env|
+      assert_equal 'www.puppetlinter.com', env[:url].host
+      assert_equal 'application/json', env[:request_headers]['Content-Type']
+      [200, {}, '']
+    end
+
+    svc = service(:push, payload)
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::Puppetlinter, *args
+  end
+end


### PR DESCRIPTION
Added support for a [Puppet Online Linter service hook](http://www.puppetlinter.com/github).
