### PR TITLE
Add a service hook for Habitualist

### DIFF
--- a/docs/habitualist
+++ b/docs/habitualist
@@ -1,0 +1,4 @@
+Habitualist
+===========
+
+Automatically log commit activity against actions on https://habitualist.com

--- a/services/habitualist.rb
+++ b/services/habitualist.rb
@@ -1,0 +1,5 @@
+class Service::Habitualist < Service
+    def receive_push
+        http_post "https://habitualist.com/webhooks/github/", :payload => JSON.generate(payload)
+    end
+end

--- a/test/habitualist_test.rb
+++ b/test/habitualist_test.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../helper', __FILE__)
+
+class HabitualistTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    @stubs.post "/webhooks/github/" do |env|
+      assert_equal 'habitualist.com', env[:url].host
+      data = Rack::Utils.parse_query(env[:body])
+      assert_equal 1, JSON.parse(data['payload'])['a']
+      [200, {}, '']
+    end
+
+    svc = service({}, :a => 1)
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::Habitualist, *args
+  end
+end
+


### PR DESCRIPTION
Habitualist (https://habitualist.com) is a new service that helps to track the things you want to do on a regular basis (e.g. commit to an open source project once a day). Unlike most todo apps, Habitualist can handle variably-recurring tasks like “floss two times a day”, “blog every 2-4 days”, “workout 3 times a week”.

This hook will enable people to auto-log their development activities. We have currently been testing with just a Webhook URL, but having this as a first class Service will make it easier for our users.
