### PR TITLE
Using SSL when delivering payloads to kanbanery.com

### DIFF
--- a/services/kanbanery.rb
+++ b/services/kanbanery.rb
@@ -6,7 +6,7 @@ class Service::Kanbanery < Service
     project_id = data['project_id']
     token = data['project_token']
 
-    http_post "http://kanbanery.com/api/v1/projects/#{project_id}/git_commits",
+    http_post "https://kanbanery.com/api/v1/projects/#{project_id}/git_commits",
       payload.to_json,
       'X-Kanbanery-ProjectGitHubToken' => token,
       'Content-Type' => 'application/json'


### PR DESCRIPTION
Dear Github Team,

we are changing the preferred way to access kanbanery.com to SSL connection, so could you please accept and merge the following pull request?

Cheers!
