### PR TITLE
Added a 'short format' to the twitter hook.

### DIFF
--- a/docs/twitter
+++ b/docs/twitter
@@ -5,4 +5,7 @@ Install Notes
   2. You're going to be redirected to twitter to allow GitHub to tweet on your behalf.
   3. Be sure that you're logged in as the twitter user you would like to tweet from.
 
+Check "short format" to omit the repository and commiter's names from the tweet to get more
+space for the commit message.
+
 [authorize_url]: <%= twitter_oauth_path(current_repository.user, current_repository) %>

--- a/services/twitter.rb
+++ b/services/twitter.rb
@@ -1,6 +1,6 @@
 class Service::Twitter < Service
   string  :token, :secret
-  boolean :digest
+  boolean :digest, :short_format
 
   def receive_push
     return unless payload['commits']
@@ -12,13 +12,21 @@ class Service::Twitter < Service
       commit = payload['commits'][-1]
       author = commit['author'] || {}
       tiny_url = shorten_url("#{payload['repository']['url']}/commits/#{ref_name}")
-      status = "[#{repository}] #{tiny_url} #{author['name']} - #{payload['commits'].length} commits"
+      status = if data['short_format'] == '1'
+        "Git: #{tinyurl} - #{payload['commits'].length} commits"
+      else
+        "[#{repository}] #{tiny_url} #{author['name']} - #{payload['commits'].length} commits"
+      end
       status.length >= 140 ? statuses << status[0..136] + '...' : statuses << status
     else
       payload['commits'].each do |commit|
         author = commit['author'] || {}
         tiny_url = shorten_url(commit['url'])
-        status = "[#{repository}] #{tiny_url} #{author['name']} - #{commit['message']}"
+        status = if data['short_format'] == '1'
+          "Git: #{tiny_url} #{commit['message']}"
+        else
+          "[#{repository}] #{tiny_url} #{author['name']} - #{commit['message']}"
+        end
         status.length >= 140 ? statuses << status[0..136] + '...' : statuses << status
       end
     end


### PR DESCRIPTION
The current tweet format is
"[$repository] $url $author - $message". Since tweets only allow 140 chars it would be nice to also have a shorter format available.

This Pull requests adds another format:
"Git: $url $message". This is useful when sou have a twitter account especially for one project and want to use the twitter hook to inform your users about new versions. Even the author's name would be wasted space in this case.
