### PR TITLE
Fix minor formatting typo in IRC docs

### DIFF
--- a/docs/irc
+++ b/docs/irc
@@ -4,7 +4,7 @@
 4.  `password` - Server password (optional)
 5.  `nick` - Nickame (optional)
 6.  `long_url` - If enabled, displays full compare/commit url's. If disabled uses bit.ly.
-7.  `message_without_join' - If enabled prevents joining and immediately leaving the channel.
+7.  `message_without_join` - If enabled prevents joining and immediately leaving the channel.
 8. `no_colors` - Disables color support for messages
 9. `notice` - Enables notice support.  Make sure you configure channel to support notices ("/mode #yourchannelname -n" or "/msg chanserv set mlock -n")
 10. `active` - Enables the bot


### PR DESCRIPTION
A single quote was used instead of a backtick to close an inline code block; this pull request fixes that.
