### PR TITLE
Add PythonPackages service for pythonpackages.com

### DIFF
--- a/docs/pythonpackages
+++ b/docs/pythonpackages
@@ -1,0 +1,6 @@
+
+PythonPackages
+==============
+
+Automatically release Python packages from GitHub to the Python Package Index ('http://pypi.python.org'). For more information, please see: ('http://docs.pythonpackages.com/en/latest/github-service.html').
+

--- a/services/pythonpackages.rb
+++ b/services/pythonpackages.rb
@@ -1,0 +1,5 @@
+class Service::PythonPackages < Service
+  def receive_push
+    http_post "https://pythonpackages.com/github", :payload => JSON.generate(payload)
+  end
+end

--- a/test/pythonpackages_test.rb
+++ b/test/pythonpackages_test.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../helper', __FILE__)
+
+class PythonPackagesTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    @stubs.post "/github" do |env|
+      assert_equal 'pythonpackages.com', env[:url].host
+      data = Rack::Utils.parse_query(env[:body])
+      assert_equal 1, JSON.parse(data['payload'])['a']
+      [200, {}, '']
+    end
+
+    svc = service({}, :a => 1)
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::PythonPackages, *args
+  end
+end
+


### PR DESCRIPTION
This service allows you to release Python packages from GitHub to the Python Package Index, simply by pushing a commit message that begins with "Release" e.g. "Release 0.0.1".
