### PR TITLE
Add a switch to send full commit messages to the CIA service hook

### DIFF
--- a/docs/cia
+++ b/docs/cia
@@ -4,4 +4,5 @@
 4. `branch` lets you specify the branch name, or a template with `%s` to fill the branch name in.
 5. `long_urls` enables full URLs instead of shortened URLs.
 6. `module` sets the module name in the project.
+7. `full_commits` enables sending full commit messages to CIA (as opposed to just the first line).
 

--- a/services/cia.rb
+++ b/services/cia.rb
@@ -1,6 +1,6 @@
 class Service::CIA < Service
   string :address, :project, :branch, :module
-  boolean :long_url
+  boolean :long_url, :full_commits
   white_list :address, :project, :branch, :module
 
   def receive_push
@@ -54,7 +54,8 @@ class Service::CIA < Service
   end
 
   def build_cia_commit(repository, branch, sha1, commit, module_name, size = 1)
-    log = commit['message'].split("\n")[0]
+    log_lines = commit['message'].split("\n")
+    log = log_lines.shift
     log << " (+#{size} more commits...)" if size > 1
 
     dt         = DateTime.parse(commit['timestamp']).new_offset
@@ -63,6 +64,12 @@ class Service::CIA < Service
     tiny_url   = data['long_url'].to_i == 1 ? commit['url'] : shorten_url(commit['url'])
 
     log << " - #{tiny_url}"
+
+    if data['full_commits'].to_i == 1
+      log_lines.each do |log_line|
+        log << "\n" << log_line
+      end
+    end
 
     <<-MSG
       <message>


### PR DESCRIPTION
Many people prefer to format their Git commit messages like emails for
various reasons, and the current CIA hook used at Github only sends the
first (subject) line of each message to the CIA server every time, thus
forcing people to either break convention by squashing all the important
bits in the same single line, or click on the included link every time
to see the full message.

The CIA bots do their own filtering to ensure they don't flood IRC
channels with long commit messages, so this shouldn't really be the
commit hook's responsibility.

However, some people might still prefer to see only the subject lines on
their channels. Thus, an additional full commit messages option is
provided in this commit for the benefit of both camps.
