### PR TITLE
Do not check ShiningPanda CI SSL certificate

### DIFF
--- a/services/shiningpanda.rb
+++ b/services/shiningpanda.rb
@@ -3,6 +3,7 @@ class Service::ShiningPanda < Service
   white_list :workspace, :job, :branches, :parameters
 
   def receive_push
+    http.ssl[:verify] = false # :(
     if workspace.empty?
       raise_config_error 'Workspace not set'
     end


### PR DESCRIPTION
Hi,

Some ShiningPanda CI users are experiencing problems with our SSL certificate. So until the cause is fully understood and the problem solved, we deactivate the SSL certificate verification.

Thanks!
