### PR TITLE
(#387) make jira transitions strings

### DIFF
--- a/services/jira.rb
+++ b/services/jira.rb
@@ -22,9 +22,9 @@ class Service::Jira < Service
         key, value = entry.split(':')
 
         if key =~ /(?i)status|(?i)transition/
-          changeset.merge!(:transition => value.to_i)
+          changeset.merge!(:transition => value.to_s)
         elsif key =~ /(?i)resolution/
-          changeset.merge!(:fields => { :resolution => value.to_i })
+          changeset.merge!(:fields => { :resolution => value.to_s })
         else
           changeset.merge!(:fields => { key.to_sym => "Resolved" })
         end


### PR DESCRIPTION
Addresses problems raised in github/github-services#387 where the transition ids must be strings, not integers, for the more recent versions of the JIRA api.
