### PR TITLE
add info about non-push types to readme

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -95,3 +95,17 @@ You can also test your hook with the Sinatra web service:
    just editing the "data" values but leaving the "payload" alone.)
 3. Send the docs/github_payload file to your service by calling:
    `./script/deliver_payload [service-name]`
+
+Other hook types
+----------------
+
+The default hook for a service is `push`. You may wish to have services respond
+to other event types, like `pull_request` or `issues`. The full list may be 
+found in [service.rb](../blob/master/lib/service.rb#L134).
+Unless your service specifies `default_events <list_of_types>`, only the `push` 
+hook will be called, see 
+[service.rb#default_events](../blob/master/lib/service.rb#L126).
+
+To make use of these additional types, your service will either need to define 
+`receive_<type>` (like `receive_pull_request_review_comment`) or a generic 
+`receive_event`.


### PR DESCRIPTION
The current readme mentions nothing of event types other than `push`, which leaves service developers either, at worst, ignorant of the possibility of creating hooks for any of the other types or, at best, hunting through other services looking for examples of what can be done.

The new readme mentions that other hooks are available, and the authoritative list can be found in lib/service.rb#L134. The new readme also now mentions that if you want to enable functionality for something other than `push` calling `default_events :push, <other_type>` is just as necessary as defining `receive_<other_type>`.
