### PR TITLE
Added tests for new OnTime API path

### DIFF
--- a/test/ontime_test.rb
+++ b/test/ontime_test.rb
@@ -6,6 +6,7 @@ class OnTimeTest < Service::TestCase
     @stubs = Faraday::Adapter::Test::Stubs.new
   end
 
+  # This tests the old api paths of OnTime. Where 11.1.0 <= Version < 12.2.0
   def test_push
     @stubs.get "/api/version" do |env|
       assert_equal 'www.example.com', env[:url].host
@@ -17,6 +18,21 @@ class OnTimeTest < Service::TestCase
     end
 
     svc = service({'ontime_url' => 'http://www.example.com/', 'api_key' => 'test_api_key'}, payload)
+    svc.receive_push
+  end
+  
+  # This tests the new api path for GitHub in OnTime Version 12.2 and later.
+  def test_push_v1_api
+    @stubs.get "/v122/api/version" do |env|
+      assert_equals 'www.example.com', env[:url].host
+      [200, {}, '{"data":{"major":12,"minor":2,"build":0}}']
+    end
+
+    @stubs.post "/v122/api/v1/github" do |env|
+      [200, {}, '']
+    end
+
+    svc = service({'ontime_url' => 'http://www.example.com/v122', 'api_key' => 'test_v1_api_key'}, payload)
     svc.receive_push
   end
 


### PR DESCRIPTION
I added a test case that tests versions of OnTime that will use the new API path.

Also technoweenie is awesomesauce.
