### PR TITLE
Replace references to bit.ly with git.io

### DIFF
--- a/docs/irc
+++ b/docs/irc
@@ -3,7 +3,7 @@
 3.  `room` - Supports single or multiple rooms (comma separated).  Also supports room passwords (room_name::password).  Prefixing '#' to the room is optional.
 4.  `password` - Server password (optional)
 5.  `nick` - Nickame (optional)
-6.  `long_url` - If enabled, displays full compare/commit url's. If disabled uses bit.ly.
+6.  `long_url` - If enabled, displays full compare/commit url's. If disabled uses git.io.
 7.  `message_without_join` - If enabled prevents joining and immediately leaving the channel.
 8. `no_colors` - Disables color support for messages
 9. `notice` - Enables notice support.  Make sure you configure channel to support notices ("/mode #yourchannelname -n" or "/msg chanserv set mlock -n")

--- a/lib/service.rb
+++ b/lib/service.rb
@@ -428,11 +428,11 @@ class Service
     @http = @secrets = @email_config = nil
   end
 
-  # Public: Shortens the given URL with bit.ly.
+  # Public: Shortens the given URL with git.io.
   #
   # url - String URL to be shortened.
   #
-  # Returns the String URL response from bit.ly.
+  # Returns the String URL response from git.io.
   def shorten_url(url)
     res = http_post("http://git.io", :url => url)
     if res.status == 201


### PR DESCRIPTION
I've found three references to bit.ly, replaced with the new URL shortener git.io.
