### PR TITLE
Make the Amazon SNS and SQS Queue services receive any event

### DIFF
--- a/docs/amazonsns
+++ b/docs/amazonsns
@@ -1,7 +1,7 @@
 Amazon Simple Notification Service
 ==================================
 
-This service lets you publish push messages to Amazon's Simple Notification Service.  Optionally, you can set up an Amazon SQS subscriber if 'sqs_queue' is specified.
+This service lets you publish event messages to Amazon's Simple Notification Service.  Optionally, you can set up an Amazon SQS subscriber if 'sqs_queue' is specified.
 
 Install Notes
 -------------

--- a/services/amazon_sns.rb
+++ b/services/amazon_sns.rb
@@ -5,7 +5,7 @@ class Service::AmazonSNS < Service
   white_list :aws_key, :sns_topic, :sqs_queue
   password :aws_secret
 
-  def receive_push
+  def receive_event
     raise_config_error "Missing 'aws_key'"    if data['aws_key'].to_s == ''
     raise_config_error "Missing 'aws_secret'" if data['aws_secret'].to_s == ''
     raise_config_error "Missing 'sns_topic'" if data['sns_topic'].to_s == ''

--- a/services/sqs_queue.rb
+++ b/services/sqs_queue.rb
@@ -3,8 +3,8 @@ class Service::SqsQueue < Service
   password :aws_secret_key
   white_list :aws_access_key, :sqs_queue_name
 
-  # receive_push()
-  def receive_push
+  # receive_event()
+  def receive_event
     return unless data && payload
 
     if data['aws_access_key'].to_s.empty?

--- a/test/amazon_sns_test.rb
+++ b/test/amazon_sns_test.rb
@@ -11,12 +11,12 @@ class AmazonSNSTest < Service::TestCase
   end
 
 
-  def test_push
+  def test_event
     svc = service :push, data, payload
     svc.aws_sdk_sns = aws_sns_stub
     svc.aws_sdk_sqs = aws_sqs_stub
 
-    svc.receive_push
+    svc.receive_event
 
     assert_equal 1, svc.aws_sdk_sns.topics.topic.messages.size
     assert_equal data['aws_key'], svc.data['aws_key']
@@ -25,7 +25,7 @@ class AmazonSNSTest < Service::TestCase
 
   end
 
-  def test_push_with_sqs_subscriber
+  def test_event_with_sqs_subscriber
 
     data_copy = data.clone
     data_copy['sqs_queue'] = 'q'
@@ -34,7 +34,7 @@ class AmazonSNSTest < Service::TestCase
     svc.aws_sdk_sns = aws_sns_stub
     svc.aws_sdk_sqs = aws_sqs_stub
 
-    svc.receive_push
+    svc.receive_event
 
     assert_equal 1, svc.aws_sdk_sns.topics.topic.messages.size
     assert_equal data_copy['sqs_queue'], svc.aws_sdk_sns.topics.topic.subscribers[0].name
@@ -53,7 +53,7 @@ class AmazonSNSTest < Service::TestCase
       svc = service :push, data, payload
 
       assert_raise Service::ConfigurationError do
-        svc.receive
+        svc.receive_event
       end
   end
 
@@ -65,7 +65,7 @@ class AmazonSNSTest < Service::TestCase
       svc = service :push, data, payload
 
       assert_raise Service::ConfigurationError do
-        svc.receive
+        svc.receive_event
       end
   end
 
@@ -77,7 +77,7 @@ class AmazonSNSTest < Service::TestCase
       svc = service :push, data, payload
 
       assert_raise Service::ConfigurationError do
-        svc.receive
+        svc.receive_event
       end
   end
 


### PR DESCRIPTION
Changes the receive_push method to receive_event so they can be configured to receive any event. Since no default is specified, they will continue to default to just receiving pushes unless others are requested.
