### PR TITLE
Add support for CoffeeDoc.info (take 2)

### DIFF
--- a/docs/coffeedocinfo
+++ b/docs/coffeedocinfo
@@ -1,0 +1,2 @@
+This service allows you to auto-publish documentation for your CoffeeScript library.
+The resulting documentation will be hosted for you at http://coffeedoc.info/github/your-name/your-project

--- a/services/coffeedocinfo.rb
+++ b/services/coffeedocinfo.rb
@@ -1,0 +1,16 @@
+class Service::CoffeeDocInfo < Service
+  self.title = 'CoffeeDoc.info'
+
+  default_events :push
+
+  url "http://coffeedoc.info/"
+
+  maintained_by :github => 'pwnall'
+
+  supported_by :web => 'https://github.com/netzpirat/coffeedoc.info',
+               :twitter => 'netzpirat', :github => 'netzpirat'
+
+  def receive_push
+    http_post 'http://coffeedoc.info/checkout', :payload => payload.to_json
+  end
+end

--- a/test/coffeedocinfo_test.rb
+++ b/test/coffeedocinfo_test.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../helper', __FILE__)
+
+class CoffeeDocInfoTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    @stubs.post "/checkout" do |env|
+      assert_equal 'coffeedoc.info', env[:url].host
+      data = Rack::Utils.parse_query(env[:body])
+      assert_equal 1, JSON.parse(data['payload'])['a']
+      [200, {}, '']
+    end
+
+    svc = service({}, :a => 1)
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::CoffeeDocInfo, *args
+  end
+end
+


### PR DESCRIPTION
[http://coffeedoc.info](CoffeeDoc.info) :: CoffeeScript -> RDocInfo :: Ruby

Please add this to GitHub.

This is a continuation of [an old pull request](https://github.com/github/github-services/pull/431) that closed itself on me while I was rebasing things.
