### PR TITLE
Update services/toggl.rb

### DIFF
--- a/services/toggl.rb
+++ b/services/toggl.rb
@@ -3,7 +3,7 @@ class Service::Toggl < Service
   white_list :project
 
   def receive_push
-    http.url_prefix = "https://www.toggl.com/api/v5"
+    http.url_prefix = "https://www.toggl.com/api/v6"
     http.basic_auth data['api_token'], 'api_token'
     http.headers['Content-Type'] = 'application/json'
 
@@ -18,7 +18,9 @@ class Service::Toggl < Service
         :task => {
           :duration => duration.to_i,
           :description => commit["message"].strip,
-          :project => data["project"],
+          :project => {
+            :id => data["project"]
+          },
           :start => (Time.now - duration.to_i).iso8601,
           :billable => true,
           :created_with => "github",


### PR DESCRIPTION
Update to V6 as V5 seems not to work. (dont get any tasks to toggl)

what i see from the sample json string in the apidoc it should be enough to provide the project id as object under project.

i'm no ruby coder, so i hope i got the syntax right.
