### PR TITLE
If domain included a trailing slash Packagist would reject the notification

### DIFF
--- a/services/packagist.rb
+++ b/services/packagist.rb
@@ -1,5 +1,5 @@
 class Service::Packagist < Service
-  string :domain, :user, :token
+  string :user, :token, :domain
   white_list :domain, :user
 
   def receive_push
@@ -38,7 +38,7 @@ class Service::Packagist < Service
       'http://packagist.org'
     else
       data['domain']
-    end.strip
+    end.lstrip.sub(/[\/\s]+$/,'')
   end
 
   def domain_parts

--- a/test/packagist_test.rb
+++ b/test/packagist_test.rb
@@ -65,6 +65,44 @@ class PackagistTest < Service::TestCase
     assert_equal 'http', svc.scheme
   end
 
+  def test_detects_http_url
+    data = {
+      'domain' => 'http://packagist.example.com/'
+    }
+
+    svc = service(data, payload)
+    assert_equal 'packagist.example.com', svc.domain
+    assert_equal 'http', svc.scheme
+  end
+
+  def test_detects_https_url
+    data = {
+      'domain' => 'https://packagist.example.com/'
+    }
+
+    svc = service(data, payload)
+    assert_equal 'packagist.example.com', svc.domain
+    assert_equal 'https', svc.scheme
+  end
+
+  def test_strips_trailing_slash
+    data = {
+      'domain' => 'packagist.example.com/   '
+    }
+
+    svc = service(data, payload)
+    assert_equal 'packagist.example.com', svc.domain
+  end
+
+  def test_strips_trailing_slash_deep_path
+    data = {
+      'domain' => 'packagist.example.com/path/to/subdirectory/  '
+    }
+
+    svc = service(data, payload)
+    assert_equal 'packagist.example.com/path/to/subdirectory', svc.domain
+  end
+
   def test_infers_user_from_repo_data
     svc = service(data.reject{|key,v| key == 'user'}, payload)
     assert_equal "mojombo", svc.user


### PR DESCRIPTION
If `http://packagist.org/` was entered, the URL being generated was `http://packagist.org//api/github` which would fail as it is not a valid route.

Fixed by replacing the strip command with lstrip followed by a regex to replace any trailing slashes or whitespace with nothing.

Added tests to ensure it is doing what is expected.

/cc @seldaek
