### PR TITLE
Fixes authentication issues with the Nodejitsu API

### DIFF
--- a/docs/nodejitsu
+++ b/docs/nodejitsu
@@ -6,13 +6,31 @@ Nodejitsu – Intelligent, scalable Node.js clouds.
 Install Notes
 -------------
 
-  1.  Create an account
-  2.  Enter your credentials
-      - Username
-      - Password
-      - Branch, if specified will only deploy from this branch
-      - Enter the host of your Nodejitsu installation (defaults to https://webhooks.nodejitsu.com), the protocol-prefix is optional and defaults to "https://".
+Create an account at http://nodejitsu.com and login there.
 
+  1.  Enter your credentials
+      - Username
+      - Password (Authorization Token suggested, password also works)
+      - Branch, if specified will only deploy from the specified branch
   3.  Check the "Active" checkbox and click "Update Settings".
   4.  Click on the "Nodejitsu" service name and then click the "Test Hook" link.
 
+API Documentation
+-----------------
+
+Please refer to https://webhooks.nodejitsu.com for documentation.
+
+Travis CI Integration
+---------------------
+
+It is possible to integrate this endpoint with Travis-CI. Check out blog for more information.
+
+Running in your own Nodejitsu Cloud
+-----------------------------------
+
+If you own a copy of Nodejitsu Enterprise you can set the `endpoint` that you wish to use for your installation. Simply enter the host of your Nodejitsu Web Hooks API Copy (defaults to https://webhooks.nodejitsu.com).
+
+Support
+-------
+
+Join #nodejitsu on irc.freenode.net and get immediate assistance from our support team!

--- a/services/nodejitsu.rb
+++ b/services/nodejitsu.rb
@@ -1,8 +1,9 @@
 # based on the travis.rb service
 class Service::Nodejitsu < Service
-  string :subdomain, :username, :branch
+  string :username
   password :password
-  white_list :subdomain, :username, :branch
+  string :branch, :endpoint
+  white_list :endpoint, :username, :branch
 
   def receive_push
     return if branch.to_s != '' && branch != branch_name
@@ -25,17 +26,17 @@ class Service::Nodejitsu < Service
 
   def branch
     if data['branch'].to_s == ''
-      data['branch']
+      'master'
     else
-       'master'
+       data['branch']
     end.strip
   end
 
   def password
     if data['password'].to_s == ''
-      data['password']
+      ''
     else
-       ''
+       data['password']
     end.strip
   end
 
@@ -50,10 +51,10 @@ class Service::Nodejitsu < Service
   protected
 
   def full_domain
-    if data['domain'].to_s == ''
+    if data['endpoint'].to_s == ''
       'https://webhooks.nodejitsu.com'
     else
-      data['domain']
+      data['endpoint']
     end.strip
   end
 

--- a/test/nodejitsu_test.rb
+++ b/test/nodejitsu_test.rb
@@ -23,8 +23,13 @@ class NodejitsuTest < Service::TestCase
   end
 
   def test_keeps_http_scheme
-    svc = service(data.merge({'domain' => 'http://example.com'}), payload)
+    svc = service(data.merge({'endpoint' => 'http://example.com'}), payload)
     assert_equal 'http', svc.scheme
+  end
+
+  def test_keeps_domain
+    svc = service(data.merge({'endpoint' => 'http://example.com'}), payload)
+    assert_equal 'example.com', svc.domain
   end
 
   def test_constructs_post_receive_url
@@ -45,14 +50,15 @@ class NodejitsuTest < Service::TestCase
     data = {
       'username' => 'kronn  ',
       'password' => '5373dd4a3648b88fa9acb8e46ebc188a  ',
-      'domain' => 'webhooks.nodejitsu.com   ',
+      'endpoint' => 'hooks.nodejitsu.com   ',
       'branch' => 'integration  '
     }
 
     svc = service(data, payload)
     assert_equal 'kronn', svc.username
     assert_equal '5373dd4a3648b88fa9acb8e46ebc188a', svc.password
-    assert_equal 'webhooks.nodejitsu.com', svc.domain
+    assert_equal 'hooks.nodejitsu.com', svc.domain
+    assert_equal 'https', svc.scheme
     assert_equal 'integration', svc.branch
   end
 
@@ -69,7 +75,7 @@ class NodejitsuTest < Service::TestCase
     assert_equal '5373dd4a3648b88fa9acb8e46ebc188a', svc.password
     assert_equal 'webhooks.nodejitsu.com', svc.domain
     assert_equal 'https', svc.scheme
-    assert_equal '', svc.branch
+    assert_equal 'master', svc.branch
   end
 
   def test_infers_user_from_repo_data


### PR DESCRIPTION
## Nodejitsu API

Can you please also alter the UI to be:
- Username
- Password (Or Token)
- Branch
- Endpoint

Thank you!
The Nodejitsu Team
### Change log

This fixes two issues with our endpoint:
- Password was not being sent, causing all deploys to fail
- Branch could not be selected.
- Our tests was not picked up cause it lacked the `_test` postfix.
