### PR TITLE
Minor fix for links

### DIFF
--- a/docs/pythonpackages
+++ b/docs/pythonpackages
@@ -1,6 +1,5 @@
-
 PythonPackages
 ==============
 
-Automatically release Python packages from GitHub to the Python Package Index ('http://pypi.python.org'). For more information, please see: ('http://docs.pythonpackages.com/en/latest/github-service.html').
+Automatically release Python packages from GitHub to the [Python Package Index](http://pypi.python.org). For more information, please see: http://docs.pythonpackages.com/en/latest/github-service.html.
 


### PR DESCRIPTION
Using MarkDown to make the links easier to click. The links were previously rendering badly and there was an extra apostrophe at the end of the second link, bringing users to an unhelpful 404.
