### PR TITLE
Add branch setting to YouTrack service

### DIFF
--- a/docs/youtrack
+++ b/docs/youtrack
@@ -21,3 +21,6 @@
   - Administrator's account (e.g. 'root' user) credentials to access your YouTrack server.
 
   - Name of a user group in YouTrack, in which YouTrack will search for committer's account.
+
+  - Branch name to track. If a branch is provided, only commits to that branch will trigger
+    YouTrack commands and commits to others will be ignored. If the branch is left empty, commits on any branch will trigger commands.


### PR DESCRIPTION
Add a new setting to allow users to define a single branch to watch for
YouTrack commands. If a branch is set, only commits to that branch will
trigger posts to YouTrack. If the branch is not set then all commits
will be processed regardless of branch (current behavior).

/cc @anna239
