### PR TITLE
Don't make TeamCity build deleted branches

### DIFF
--- a/services/teamcity.rb
+++ b/services/teamcity.rb
@@ -4,6 +4,8 @@ class Service::TeamCity < Service
   white_list :base_url, :build_type_id, :username, :branches
 
   def receive_push
+    return if payload['deleted']
+
     branches = data['branches'].to_s.split(/\s+/)
     ref = payload["ref"].to_s
     branch = ref.split("/").last

--- a/test/teamcity_test.rb
+++ b/test/teamcity_test.rb
@@ -23,6 +23,21 @@ class TeamCityTest < Service::TestCase
     svc.receive_push
   end
 
+  def test_push_deleted_branch
+    url = "/abc/httpAuth/action.html"
+    @stubs.get url do |env|
+      assert false, "service should not be called for deleted branches"
+    end
+
+    svc = service({
+      'base_url' => 'http://teamcity.com/abc',
+      'build_type_id' => 'btid'
+    }, {
+      'deleted' => true
+    })
+    svc.receive_push
+  end
+
   def service(*args)
     super Service::TeamCity, *args
   end


### PR DESCRIPTION
Currently, deleting a branch on Github triggers a new build in TeamCity (7.1, using the branch wildcarding). That doesn't look right.

 An easy fix (see patch) is to quit the push handler if the payload represents a deleted branch.

Alternatively, I don't know if a better solution would be to try and delete the corresponding build type in TeamCity. The current service code seems to use the very old form-based TC4 interface, rather than the newer REST API, so I don't know if deleting builds is possible. Also, we would probably want to be compatible both with the old one-build-per-branch structure and the new TC7 multi-branch build structure.

Feedback welcome!
