### PR TITLE
Pass correct branch name with slashes to TeamCity

### DIFF
--- a/services/teamcity.rb
+++ b/services/teamcity.rb
@@ -6,7 +6,7 @@ class Service::TeamCity < Service
   def receive_push
     branches = data['branches'].to_s.split(/\s+/)
     ref = payload["ref"].to_s
-    branch = ref.split("/").last
+    branch = ref.split("/", 3).last
     return unless branches.empty? || branches.include?(branch)
 
     # :(

--- a/test/teamcity_test.rb
+++ b/test/teamcity_test.rb
@@ -23,6 +23,38 @@ class TeamCityTest < Service::TestCase
     svc.receive_push
   end
 
+  def test_push_with_branch_name
+    url = "/abc/httpAuth/action.html"
+    @stubs.get url do |env|
+      assert_equal 'branch-name', env[:params]['branchName']
+      [200, {}, '']
+    end
+
+    svc = service({
+      'base_url' => 'http://teamcity.com/abc',
+      'build_type_id' => 'btid'
+    }, {
+      'ref' => 'refs/heads/branch-name'
+    })
+    svc.receive_push
+  end
+
+  def test_push_with_branch_name_incl_slashes
+    url = "/abc/httpAuth/action.html"
+    @stubs.get url do |env|
+      assert_equal 'branch/name', env[:params]['branchName']
+      [200, {}, '']
+    end
+
+    svc = service({
+      'base_url' => 'http://teamcity.com/abc',
+      'build_type_id' => 'btid'
+    }, {
+      'ref' => 'refs/heads/branch/name'
+    })
+    svc.receive_push
+  end
+
   def service(*args)
     super Service::TeamCity, *args
   end


### PR DESCRIPTION
When using branch names with slashes (e.g. `feature/some-name`), TeamCity should receive the full branch name as `branchName` parameter and not just the last token (`some-name`).
