### PR TITLE
Add restrict_to_branch support to hipchat script

### DIFF
--- a/docs/hipchat
+++ b/docs/hipchat
@@ -7,5 +7,6 @@ Install Notes
 -------------
 
 1. **Auth Token** - One of your group's API tokens. See: http://www.hipchat.com/docs/api/auth
-2. **Room** - The full name of the room to send the message to. The room's room_id will also work.
-3. **Notify** - Whether or not to notify room members.
+2. **Restrict to Branch** - List of branches to which will be inspected
+3. **Room** - The full name of the room to send the message to. The room's room_id will also work.
+4. **Notify** - Whether or not to notify room members.

--- a/services/hipchat.rb
+++ b/services/hipchat.rb
@@ -1,7 +1,7 @@
 class Service::HipChat < Service
-  string :auth_token, :room
+  string :auth_token, :room, :restrict_to_branch
   boolean :notify
-  white_list :room
+  white_list :room, :restrict_to_branch
 
   default_events :commit_comment, :download, :fork, :fork_apply, :gollum,
     :issues, :issue_comment, :member, :public, :pull_request, :push, :watch
@@ -10,6 +10,14 @@ class Service::HipChat < Service
     # make sure we have what we need
     raise_config_error "Missing 'auth_token'" if data['auth_token'].to_s == ''
     raise_config_error "Missing 'room'" if data['room'].to_s == ''
+
+    branch = payload['ref'].split('/').last
+    branch_restriction = data['restrict_to_branch'].to_s
+
+    # check the branch restriction is poplulated and branch is not included
+    if branch_restriction.length > 0 && branch_restriction.index(branch) == nil
+      return
+    end
 
     http.headers['X-GitHub-Event'] = event.to_s
 


### PR DESCRIPTION
It restricts the notifications to an optional list  of branches. It will be necessary to change the UI (like for example in the asana hook)
