### PR TITLE
Adding tenXer as a GitHub service

### DIFF
--- a/docs/tenxer
+++ b/docs/tenxer
@@ -1,0 +1,6 @@
+tenXer
+======
+
+tenXer makes it easy to track personal and team metrics from all your cloud services, set goals to improve your stats, and see how you compare.
+
+Sign up at https://www.tenxer.com

--- a/services/tenxer.rb
+++ b/services/tenxer.rb
@@ -1,0 +1,19 @@
+class Service::Tenxer < Service
+
+  url "https://www.tenxer.com"
+  logo_url "https://www.tenxer.com/static.b58bf75/image/touch-icon-144.png"
+
+  maintained_by :github => 'tenxer'
+  supported_by :web => 'http://www.tenxer.com/faq',
+    :email => 'support@tenxer.com'
+    
+  def receive_event
+    url = "https://www.tenxer.com/updater/githubpubsubhubbub/"
+    res = http_post url, {'payload' => JSON.generate(payload)},
+      {'X_GITHUB_EVENT' => event.to_s}
+    if res.status != 200
+      raise Error, "Error sending event to tenXer. Status: " +
+        res.status.to_s + ": " + res.body
+    end    
+  end
+end

--- a/test/tenxer_test.rb
+++ b/test/tenxer_test.rb
@@ -1,0 +1,45 @@
+require File.expand_path('../helper', __FILE__)
+
+class TenxerTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def post_checker(event)
+    return lambda { |env|
+      assert_equal "https", env[:url].scheme
+      assert_equal "www.tenxer.com", env[:url].host
+      assert_match "payload=%7B%22test%22%3A%22payload%22%7D", env[:body]
+      assert_equal event, env[:request_headers]["X_GITHUB_EVENT"]
+      return [200, {}, ''] }
+  end
+
+  def test_push
+    checker = post_checker "push"
+    @stubs.post "/updater/githubpubsubhubbub", &checker
+
+    svc = service(:push, {}, {'test' => 'payload'})
+    svc.receive_event
+  end
+
+  def test_pull_request
+    checker = post_checker "pull_request"
+    @stubs.post "/updater/githubpubsubhubbub", &checker
+
+    svc = service(:pull_request, {}, {'test' => 'payload'})
+    svc.receive_event
+  end
+
+  
+  def test_issues
+    checker = post_checker "issues"
+    @stubs.post "/updater/githubpubsubhubbub", &checker
+  
+    svc = service(:issues, {}, {'test' => 'payload'})
+    svc.receive_event
+  end
+   
+  def service(*args)
+    super Service::Tenxer, *args
+  end
+end


### PR DESCRIPTION
This service sends data to [tenXer](https://www.tenxer.com)
