### PR TITLE
add service for jQuery plugins site

### DIFF
--- a/docs/jquery_plugins
+++ b/docs/jquery_plugins
@@ -1,0 +1,4 @@
+jQuery Plugins
+==============
+
+This service notifies the [jQuery Plugin site](http://plugins.jquery.com) of any new releases to your jQuery plugin. See [http://plugins.jquery.com/docs/publish/](http://plugins.jquery.com/docs/publish/) for more information.

--- a/services/jquery_plugins.rb
+++ b/services/jquery_plugins.rb
@@ -1,0 +1,15 @@
+class Service::JqueryPlugins < Service
+
+  url "http://plugins.jquery.com/"
+
+  logo_url "http://plugins.jquery.com/jquery-wp-content/themes/jquery/images/logo-jquery.png"
+  
+  maintained_by :github => 'dwradcliffe', :twitter => 'dwradcliffe'
+  
+  supported_by :email => 'plugins@jquery.com'
+
+  def receive_push
+    http_post "http://plugins.jquery.com/postreceive-hook", :payload => payload.to_json
+  end
+
+end

--- a/test/jquery_plugins_test.rb
+++ b/test/jquery_plugins_test.rb
@@ -1,0 +1,27 @@
+require File.expand_path('../helper', __FILE__)
+
+class JqueryPluginsTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    svc = service :push, {}, 'a' => 1
+
+    @stubs.post "/postreceive-hook" do |env|
+      assert_equal 'plugins.jquery.com', env[:url].host
+      data = Rack::Utils.parse_nested_query(env[:body])
+      assert_equal 1, JSON.parse(data['payload'])['a']
+      [200, {}, '']
+    end
+
+    svc.receive
+
+    @stubs.verify_stubbed_calls
+  end
+
+  def service(*args)
+    super Service::JqueryPlugins, *args
+  end
+end
+


### PR DESCRIPTION
Adds a service for the new jQuery plugins site.
See jquery/plugins.jquery.com#83
