### PR TITLE
HipChat: Add boolean to ignore forks and watches

### DIFF
--- a/services/hipchat.rb
+++ b/services/hipchat.rb
@@ -1,6 +1,6 @@
 class Service::HipChat < Service
   string :auth_token, :room, :restrict_to_branch
-  boolean :notify, :quiet_fork_and_watch
+  boolean :notify, :quiet_fork, :quiet_watch
   white_list :room, :restrict_to_branch
 
   default_events :commit_comment, :download, :fork, :fork_apply, :gollum,
@@ -23,7 +23,8 @@ class Service::HipChat < Service
     end
     
     # ignore forks and watches if boolean is set
-    return if ["fork", "watch"].include?(event.to_s) && data['quiet_fork_and_watch']
+    return if event.to_s =~ /fork/ && data['quiet_fork']
+    return if event.to_s =~ /watch/ && data['quiet_watch']
 
     http.headers['X-GitHub-Event'] = event.to_s
 


### PR DESCRIPTION
Take 2.

I'd like to offer a way to quiet those dang "fork" and "watch" events. For the projects I work on, they become noise in a HipChat room where we're trying to get meaningful stuff done and discussed. It's important to me that we have less of this noise.

In #487, I proposed removing them altogether, but @technoweenie thought they had better check with the HipChat staff, and it was ultimately denied. This is a compromise: allow users (on the GitHub side) to quiet these events by selecting a checkbox. This pull request proposes an opt-out solution, keeping the default the same, but allowing for a little flexibility and noise-reduction capabilities.

Let me know what you think -- I'm definitely eager to have this as an option, at least.
