### PR TITLE
Change domain from hub.ci to node.ci

### DIFF
--- a/services/nodeci.rb
+++ b/services/nodeci.rb
@@ -8,7 +8,7 @@ class Service::HubCI < Service
   end
 
   def hubci_url
-    "https://hub.ci/repository/#{repoOwner}/#{repoName}/onCommit/#{token}"
+    "https://node.ci/repository/#{repoOwner}/#{repoName}/onCommit/#{token}"
   end
 
   def repoName


### PR DESCRIPTION
We changed our domain name, so we delete old file (hubci.rb) and replace it with the new one (nodeci.rb)
