### PR TITLE
Changed repo_uri to use URI provided in payload

### DIFF
--- a/services/rally.rb
+++ b/services/rally.rb
@@ -20,7 +20,7 @@ class Service::Rally < Service
     branch     = payload['ref'].split('/')[-1]  # most of the time it'll be refs/heads/master ==> master
     repo       = payload['repository']['name']
     repo_owner = payload['repository']['owner']['name']
-    repo_uri   = 'https://github.com/%s/%s' % [repo_owner, repo]
+    repo_uri   = payload['repository']['url']
 
     http.ssl[:verify] = false
     if server =~ /^https?:\/\//   # if they have http:// or https://, leave server value unchanged


### PR DESCRIPTION
repo_uri now uses the url field in the payload hash, which should
be equivalent to its prior semi-hardcoded value on github.com. Fixes an
issue experienced by GitHub:Enterprise customers using the Rally
integration.
