### PR TITLE
DeployHQ Support

### DIFF
--- a/docs/deployhq
+++ b/docs/deployhq
@@ -1,0 +1,17 @@
+DeployHQ
+--------
+
+DeployHQ is a service which lets you deploy directly
+from your GitHub repository to your server via FTP or
+SSH/SFTP.
+
+Install Notes
+-------------
+
+1. **Deploy Hook URL** Should be the automatic deployment URL of the 
+server you wish to deploy to. You can find this on the
+Edit Server or Edit Server Group page in DeployHQ.
+
+1. **Email Pusher** Specifies whether the person who pushed
+the commits should receive an email once a deployment
+is completed.

--- a/lib/services/deploy_hq.rb
+++ b/lib/services/deploy_hq.rb
@@ -1,0 +1,23 @@
+class Service::DeployHq < Service
+  string :deploy_hook_url
+  boolean :email_pusher
+  
+  url "http://www.deployhq.com/"
+  logo_url "http://www.deployhq.com/images/deploy/logo.png"
+  maintained_by :github => 'darkphnx'
+  supported_by :web => 'http://support.deployhq.com/', :email => 'support@deployhq.com'
+
+  def receive_push
+    unless data['deploy_hook_url'].to_s =~ /^https:\/\/[a-z0-9\-\_]+\.deployhq.com\/deploy\/[a-z0-9\-\_]+\/to\/[a-z0-9\-\_]+\/[a-z0-9]+$/i
+      raise_config_error "Deploy Hook invalid" 
+    end
+    email_pusher = data['email_pusher'] == "1"
+
+    http.url_prefix = data['deploy_hook_url']
+    http.headers['content-type'] = 'application/x-www-form-urlencoded'
+    body = Faraday::Utils.build_nested_query(http.params.merge(:payload => JSON.generate(payload), :notify => email_pusher))
+
+    http_post data['deploy_hook_url'], body
+  end
+
+end

--- a/test/deploy_hq_test.rb
+++ b/test/deploy_hq_test.rb
@@ -1,0 +1,34 @@
+require File.expand_path('../helper', __FILE__)
+
+class DeployHqTest < Service::TestCase
+
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    @stubs.post '/deploy/projectname/to/servername/serverkey' do |env|
+      assert_equal 'test.deployhq.com', env[:url].host
+      assert_equal 'https', env[:url].scheme
+      post_payload = JSON.parse(Rack::Utils.parse_query(env[:body])['payload'])
+
+      assert_not_nil payload['after']
+      assert_equal post_payload['after'], post_payload['after']
+      assert_not_nil post_payload['ref']
+      assert_equal payload['ref'], post_payload['ref']
+      assert_not_nil post_payload['repository']['url']
+      assert_equal payload['repository']['url'], post_payload['repository']['url']
+      assert_equal payload['pusher']['email'], post_payload['pusher']['email']
+
+      [201, [], '']
+    end
+
+    svc = service :push, { 'deploy_hook_url' => 'https://test.deployhq.com/deploy/projectname/to/servername/serverkey' }, payload
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::DeployHq, *args
+  end
+
+end


### PR DESCRIPTION
This commit introduces support for the DeployHQ deployment service (http://www.deployhq.com) which up until now has used the generic web-hook service.
