### PR TITLE
Update octocat logo in Basecamp service hook

### DIFF
--- a/lib/services/basecamp.rb
+++ b/lib/services/basecamp.rb
@@ -1,6 +1,6 @@
 class Service::Basecamp < Service
   SERVICE_NAME = 'GitHub'
-  LOGO_URL     = 'https://assets.github.com/images/modules/about_page/octocat.png'
+  LOGO_URL     = 'https://asset1.37img.com/global/github/original.png'
 
   string          :project_url, :email_address
   password        :password


### PR DESCRIPTION
...since the old URL at assets.github.com is gone.
