### PR TITLE
Allow payload to be published via AWS SNS with least amount of privileges

### DIFF
--- a/docs/amazonsns
+++ b/docs/amazonsns
@@ -8,6 +8,6 @@ Install Notes
 
 1. 'aws_key' (REQUIRED) is the Amazon Access Key ID of an account with permission to publish SNS notifications.
 2. 'aws_secret' (REQUIRED) is the Amazon Secret Access Key associated with the aws_key
-3. 'sns_topic' (REQUIRED) is the name of the Amazon SNS topic.  If no topic exists by this name, one will be created.
+3. 'sns_topic' (REQUIRED) is either the name of the Amazon SNS topic or the topic's ARN.  If no topic exists by this name, one will be created.  This service will not attempt to create the topic if the ARN is specified, thus allowing the minimum level of permissions (namely: 'sns:Publish') to be used.
 4. 'sqs_queue' (OPTIONAL) is the name of an Amazon SQS Queue to be subscribed to the sns_topic.  If no queue exists by this name, one will be created.
 

--- a/lib/services/amazon_sns.rb
+++ b/lib/services/amazon_sns.rb
@@ -11,7 +11,7 @@ class Service::AmazonSNS < Service
     raise_config_error "Missing 'aws_secret'" if data['aws_secret'].to_s == ''
     raise_config_error "Missing 'sns_topic'" if data['sns_topic'].to_s == ''
 
-    t = aws_sdk_sns.topics.create(data['sns_topic'])
+    t = get_topic(data['sns_topic'])
 
     if(data['sqs_queue'].to_s != '')
       q = aws_sdk_sqs.queues.create(data['sqs_queue'])
@@ -35,4 +35,11 @@ class Service::AmazonSNS < Service
     {:access_key_id=>data['aws_key'], :secret_access_key=>data['aws_secret']}
   end
 
+  def get_topic(name_or_arn)
+    if name_or_arn =~ /^arn:aws:sns:/
+      aws_sdk_sns.topics[name_or_arn]
+    else
+      aws_sdk_sns.topics.create(name_or_arn)
+    end
+  end
 end


### PR DESCRIPTION
## Before this fix

In order to use this hook with an AWS account, you have to use credentials (access key and secret key) that are imbued with privileges: `sns:CreateTopic` and `sns:Publish`
## After this fix

The fact that `sns_topic` is set to a topic ARN (e.g. `arn:aws:sns:us-east-1:111222333444:some-topic`) is used as a hint that we **know** what topic to use, instead of implying that we want it created in case it doesn't exist.

So, in such cases, no topic creation is attempted at all. Instead a "publish" action is done straight against the ARN specified.

As a result, the AWS credentials you specify need only to have `sns:Publish` for the given topic ARN and nothing else.
- [x] AmazonSNS doc updated
- [x] Extra unit test(s) added
- [x] Tested locally
## Testing Done

Manual testing, using AWS credentials that only have power to publish to an SNS topic:

```
$ bundle exec irb
> require 'config/load'
> require 'lib/services/amazon_sns'
> 
> # illustrate what happens when used with AWS creds lacking "create topic" powers:
*
* conf = Hash['aws_key' => '...', 'aws_secret' => '...',
*             'sns_topic' => 'github-post-receive']
=> { ... }
> Service::AmazonSNS.new(:push, conf).receive_event
AWS::SNS::Errors::AuthorizationError: User: arn:aws:iam::XXXX:user/YYYY is not authorized to perform: SNS:CreateTopic on resource: arn:aws:sns:us-east-1:XXXX:github-post-receive
    from .../vendor/bundle/ruby/1.8/gems/aws-sdk-1.8.1.1/lib/aws/core/client.rb:318:in `return_or_raise'
    ...
>
> # Happy path:
*
* conf = Hash['aws_key' => '...', 'aws_secret' => '...',
*             'sns_topic' => 'arn:aws:sns:us-east-1:XXXX:github-post-receive']
=> { ... }
> Service::AmazonSNS.new(:push, conf, {'hello'=>42}).receive_event
=> "30dd0e42-5382-52d1-92b4-47f8edb4514d"
```

Unit tests:

``` sh
$ rake test
(in /Users/pavel/src/github_services)
/opt/boxen/rbenv/versions/1.8.7-p358/bin/ruby -I"lib:lib:test" "/Users/pavel/src/github_services/vendor/bundle/ruby/1.8/gems/rake-0.8.7/lib/rake/rake_test_loader.rb" "test/active_collab_test.rb" "test/acunote_test.rb" "test/agile_bench_test.rb" "test/agilezen_test.rb" "test/amazon_sns_test.rb" "test/apoio_test.rb" "test/appharbor_test.rb" "test/asana_test.rb" "test/backlog_test.rb" "test/bamboo_test.rb" "test/basecamp_classic_test.rb" "test/basecamp_test.rb" "test/boxcar_test.rb" "test/buddycloud_test.rb" "test/bugherd_test.rb" "test/bugly_test.rb" "test/bugzilla_test.rb" "test/campfire_test.rb" "test/cia_test.rb" "test/codeclimate_test.rb" "test/CodePorting-C#2Java_test.rb" "test/codeship_test.rb" "test/coffeedocinfo_test.rb" "test/conductor_test.rb" "test/coop_test.rb" "test/copperegg_test.rb" "test/cube_test.rb" "test/depending_test.rb" "test/deploy_hq_test.rb" "test/ducksboard_test.rb" "test/email_test.rb" "test/firebase_test.rb" "test/fisheye_test.rb" "test/flowdock_test.rb" "test/fog_bugz_test.rb" "test/freckle_test.rb" "test/friend_feed_test.rb" "test/gemini_test.rb" "test/gemnasium_test.rb" "test/geocommit_test.rb" "test/get_localization_test.rb" "test/git_live_test.rb" "test/grmble_test.rb" "test/group_talent_test.rb" "test/grove_test.rb" "test/habitualist_test.rb" "test/hall_test.rb" "test/harvest_test.rb" "test/hip_chat_test.rb" "test/hubcap_test.rb" "test/humbug_test.rb" "test/icescrum_test.rb" "test/irc_test.rb" "test/irker_test.rb" "test/jabber_test.rb" "test/jaconda_test.rb" "test/jenkins_git_test.rb" "test/jenkins_github_test.rb" "test/jira_test.rb" "test/jquery_plugins_test.rb" "test/kanbanery_test.rb" "test/kickoff_test.rb" "test/leanto_test.rb" "test/lighthouse_test.rb" "test/lingohub_test.rb" "test/loggly_test.rb" "test/mantis_bt_test.rb" "test/masterbranch_test.rb" "test/mqtt_test.rb" "test/nodeci_test.rb" "test/nodejitsu_test.rb" "test/notifo_test.rb" "test/notifymyandroid_test.rb" "test/ontime_test.rb" "test/pachube_test.rb" "test/packagist_test.rb" "test/pivotal_tracker_test.rb" "test/planbox_test.rb" "test/planio_test.rb" "test/presently_test.rb" "test/prowl_test.rb" "test/puppetlinter_test.rb" "test/push_test.rb" "test/pushover_test.rb" "test/pythonpackages_test.rb" "test/rails_brakeman_test.rb" "test/railsbp_test.rb" "test/rally_test.rb" "test/rapidpush_test.rb" "test/rational_team_concert_test.rb" "test/rdocinfo_test.rb" "test/read_the_docs_test.rb" "test/redmine_test.rb" "test/rubyforge_test.rb" "test/schema_test.rb" "test/scrumdo_test.rb" "test/service_test.rb" "test/shiningpanda_test.rb" "test/slatebox_test.rb" "test/socialcast_test.rb" "test/softlayer_messaging_test.rb" "test/sourcemint_test.rb" "test/splendid_bacon_test.rb" "test/sprintly_test.rb" "test/sqs_queue_test.rb" "test/stackmob_test.rb" "test/statusnet_test.rb" "test/talker_test.rb" "test/target_process_test.rb" "test/teamcity_test.rb" "test/tender_test.rb" "test/tenxer_test.rb" "test/test_pilot_test.rb" "test/toggl_test.rb" "test/trac_test.rb" "test/trajectory_test.rb" "test/travis_test.rb" "test/trello_test.rb" "test/twilio_test.rb" "test/twitter_test.rb" "test/unfuddle_test.rb" "test/web_test.rb" "test/web_translate_it_test.rb" "test/weblate_test.rb" "test/yammer_test.rb" "test/youtrack_test.rb" "test/zendesk_test.rb" "test/zohoprojects_test.rb" 
Loaded suite /Users/pavel/src/github_services/vendor/bundle/ruby/1.8/gems/rake-0.8.7/lib/rake/rake_test_loader
Started
.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
Finished in 1.268328 seconds.
```
