### PR TITLE
README corrections

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -59,7 +59,9 @@ How to test your service
 
 You can test your service in a ruby irb console:
 
-1. Run `rake console` to start irb.
+0. Cache gems and install them to `vendor/gems` by doing:
+   `script/bootstrap`
+1. Start irb: `bundle exec irb -r config/load.rb -r lib/services/myservice.rb`
 2. Instantiate your Service:
 
     ```ruby
@@ -86,7 +88,7 @@ You can test your service in a ruby irb console:
 You can also use this one-liner in the shell instead:
 
   ```bash
-  bundle exec ruby -r config/load.rb -r services/myservice.rb -e \
+  bundle exec ruby -r config/load.rb -r lib/services/myservice.rb -e \
     "Service::MyService.new(:push, {'foo' => 'bar'}).receive_push"
   ```
 You can also test your hook with the Sinatra web service:


### PR DESCRIPTION
Instructions given were missing crucial `lib/` prefix. This has been fixed in "How to test your service" (8dd2a6e).

I also would like to point out that "Running the server locally" instructions are broken.
Assuming that `lib/` needs to be specified and `bundle exec` is used, here's how it fails:

```
$ bundle exec ruby lib/github-services.rb 
lib/github-services.rb:18:in `require': no such file to load -- basecamp (LoadError)
    from lib/github-services.rb:18
```

Look like a missing dependency.

It also talks about installing `hpricot`, but if so, shouldn't it be added to `github-services.gemspec` as a dependency.
