### PR TITLE
Better docs for Humbug service hook

### DIFF
--- a/docs/humbug
+++ b/docs/humbug
@@ -1,5 +1,5 @@
 Install Notes
 -------------
 
-1. **Email** - The username to authenticate as
-2. **Api Key** - The API key associated with the provided user
+1. **Email** - The user to authenticate as.
+2. **Api Key** - The API key associated with the provided user. See: https://humbughq.com/#settings


### PR DESCRIPTION
Added a link to the page which shows the user's API key when they're logged in. Can make adding a repo slightly faster :)
