### PR TITLE
Fix README link pointing to list of event types

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -105,7 +105,7 @@ Other hook types
 
 The default hook for a service is `push`. You may wish to have services respond
 to other event types, like `pull_request` or `issues`. The full list may be
-found in [service.rb](https://github.com/github/github-services/blob/master/lib/service.rb#L106).
+found in [service.rb](https://github.com/github/github-services/blob/master/lib/service.rb#L78).
 Unless your service specifies `default_events <list_of_types>`, only the `push`
 hook will be called, see
 [service.rb#default_events](https://github.com/github/github-services/blob/master/lib/service.rb#L198).


### PR DESCRIPTION
Just a small tweak to the link in the README pointing to the list of event types. The link [currently points to a different line in lib/service.rb](https://github.com/izuzak/github-services/blob/master/lib/service.rb#L107) (line 107, but should be line 78), probably due to service.rb being changed over time.
