### PR TITLE
Include a asciidoc server service

### DIFF
--- a/docs/asciidoc
+++ b/docs/asciidoc
@@ -1,0 +1,14 @@
+Asciidoc
+=========
+
+With this service you can generate your pdf/html/docbook from your asciidoc files.
+
+
+
+Install Notes
+-------------
+
+  1. Install a asciidoc-server (https://github.com/edusantana/asciidoc-server)
+  2. Configure it
+  3. Share the server generation settings to users
+	4. Tell users your server url to configure at service settings.

--- a/lib/services/asciidoc.rb
+++ b/lib/services/asciidoc.rb
@@ -1,0 +1,24 @@
+class Service::Asciidoc < Service
+  self.title = 'Asciidoc'
+	string     :server
+	white_list :server
+	default_events :push
+
+  url "https://github.com/edusantana/asciidoc-server/blob/master/python-cgi/README.asciidoc"
+#TODO  logo_url "http://myservice.com/logo.png"
+
+	maintained_by :github => 'edusantana'
+
+  supported_by :web => 'http://150.165.237.17/books/edusantana/producao-computacao-ead-ufpb/livro/livro.chunked/index.html',
+    :email => 'eduardo.ufpb+asciidoc@gmail.com'
+
+  def receive_push
+
+		# TODO add authencation
+		http_post data['server'], :repositorio=> payload['repository']['url'],:payload=>JSON.generate(payload)
+
+  end
+end
+
+#How to test
+#bundle exec ruby -r config/load.rb -r lib/services/asciidoc.rb -e "Service::Asciidoc.new(:push, {'server'=>'http://localhost/cgi-bin/pull-pdf.py'}).receive_push"


### PR DESCRIPTION
If you have a repository with a asciidoc book, you can configurate a asciidoc server to generate it's pdf every time a user pushes text.

I have just started a asciidoc server project at https://github.com/edusantana/asciidoc-server, you can run your own.

Since i'm working on a on-line course, we are writting a lot of books (in portuguese). I already have this server up and running. Today the authos writes text, pushes it to repository and then goes to our server and click a button to generate the book.pdf book.html and slides.html files. The server pulls the book repository and generate those.

With this service we can simplify authors life. This workflow was inspired on the _oreill_ way, but they use subversion private repository.

About testing, sorry, i don't know how to write automated tests yet. I have tested it manually.

Our server is a python cgi script, but inspired on the github way of doing, I will be writing a sinatra server later.

I'm also planning on start a free on-line server to help users to write books.
