### PR TITLE
Fix a bug with the Travis service/pull_requests

### DIFF
--- a/lib/services/travis.rb
+++ b/lib/services/travis.rb
@@ -18,7 +18,7 @@ class Service::Travis < Service
 
   def user
     if data['user'].to_s == ''
-      payload['repository']['owner']['name']
+      owner_payload['login'] || owner_payload['name']
     else
       data['user']
     end.strip
@@ -37,6 +37,10 @@ class Service::Travis < Service
   end
 
   protected
+
+  def owner_payload
+    payload['repository']['owner']
+  end
 
   def full_domain
     if data['domain'].present?

--- a/test/travis_test.rb
+++ b/test/travis_test.rb
@@ -55,6 +55,17 @@ class TravisTest < Service::TestCase
     @svc.receive_event
   end
 
+  def test_pull_request_payload_without_username
+    data = {
+      'user' => '',
+      'token' => '5373dd4a3648b88fa9acb8e46ebc188a'
+    }
+    svc = service(:pull_request, blank_user_config, pull_payload)
+
+    assert_equal pull_payload['repository']['owner']['login'], svc.user
+    assert_equal '5373dd4a3648b88fa9acb8e46ebc188a', svc.token
+  end
+
   def test_strips_whitespace_from_form_values
     data = {
       'user' => 'kronn  ',
@@ -105,6 +116,13 @@ class TravisTest < Service::TestCase
   def basic_config
     {
       'user' => 'kronn',
+      'token' => '5373dd4a3648b88fa9acb8e46ebc188a'
+    }
+  end
+
+  def blank_user_config
+    {
+      'user' => '',
       'token' => '5373dd4a3648b88fa9acb8e46ebc188a'
     }
   end


### PR DESCRIPTION
Push payloads have the owner username stored in `repository.owner.name`, while pull request payloads have the username stored in `repository.owner.login`.

This was causing a bug where pull request notifications wouldn't be sent if the username was left out in the configuration.
