### PR TITLE
Update to fix json payload

### DIFF
--- a/lib/services/conductor.rb
+++ b/lib/services/conductor.rb
@@ -15,7 +15,7 @@ class Service::Conductor < Service
 
     http.ssl[:verify] = false
     http.headers['X-GitHub-Event'] = event.to_s
-    http_post "#{self.class.url}/github/commit/#{api_key}", generate_json(:payload => payload)
+    http_post "#{self.class.url}/github/commit/#{api_key}", :payload => generate_json(payload)
   end
 
 end


### PR DESCRIPTION
The last merge by technoweenie was accompanied by a code change which killed the json payload on the client side. This broke the production system hooks and was rather unpleasant to pin down and replicate.

If you insist on changing the code, please be responsible and let clients know so we can verify it
