### PR TITLE
Fix IRC doc

### DIFF
--- a/docs/irc
+++ b/docs/irc
@@ -5,9 +5,9 @@
 5.  `nick` - Nickname (optional)
 7.  `nickserv_password` - Password for the server's [NickServ](http://en.wikipedia.org/wiki/Internet_Relay_Chat_services) (optional)
 6.  `long_url` - If enabled, displays full compare/commit url's. If disabled uses git.io.
-7.  `message_without_join` - If enabled prevents joining and immediately leaving the channel.
+7.  `message_without_join` - If enabled prevents joining and immediately leaving the channel.  Make sure you configure the channel to support outside messages ("/mode #yourchannelname -n" or "/msg chanserv set mlock -n")
 8. `no_colors` - Disables color support for messages
-9. `notice` - Enables notice support.  Make sure you configure channel to support notices ("/mode #yourchannelname -n" or "/msg chanserv set mlock -n")
+9. `notice` - Sends as a notice rather than a channel message.
 10. `branch_regexes` - Regular expressions for branch name matching (optional, comma separated). For example, only master => `^master$`, master & starts with bug => `master,^bug`.
 11. `no_pull_requests` - Turns off notifications of opened pull requests.
 12. `active` - Enables the bot


### PR DESCRIPTION
The IRC mode +n means "no external messages" and was incorrectly listed in the description of Notices as blocking the ability for the channel to have notices, so I moved it to "Message Without Join" where it belongs.
