### PR TITLE
update unfuddle documentation

### DIFF
--- a/docs/unfuddle
+++ b/docs/unfuddle
@@ -15,3 +15,5 @@ In the above, the data you need for configuration is:
 
 * subdomain: example
 * repo_id: 28573
+
+If your URL begins with http:// rather than https:// check the Httponly box when setting up the service hook.


### PR DESCRIPTION
it isn't clear from the documentation what the httponly box does.  updated the documentation so it makes sense.
