### PR TITLE
Allow multiple endpoints in Jenkins Github plugin.

### DIFF
--- a/docs/jenkins
+++ b/docs/jenkins
@@ -6,7 +6,7 @@ pushes are made to GitHub.
 Install Notes
 -------------
 
- 1. "Jenkins Hook Urls" is a list of space-separated URLs for the endpoints on a set of Jenkins servers.
+ 1. "Jenkins Hook Url" is a list of space-separated URLs for the endpoints on a set of Jenkins servers.
  For example: `http://ci.jenkins-ci.org/github-webhook/`.
 
 For more information see <https://wiki.jenkins-ci.org/display/JENKINS/GitHub+plugin>.

--- a/lib/services/jenkins_github.rb
+++ b/lib/services/jenkins_github.rb
@@ -2,12 +2,12 @@ class Service::JenkinsGitHub < Service
   self.title = 'Jenkins (GitHub plugin)'
   self.hook_name = 'jenkins' # legacy hook name
 
-  string :jenkins_hook_urls
-  white_list :jenkins_hook_urls
+  string :jenkins_hook_url
+  white_list :jenkins_hook_url
 
   def receive_push
-    if data['jenkins_hook_urls'].present?
-      hook_str = data['jenkins_hook_urls']
+    if data['jenkins_hook_url'].present?
+      hook_str = data['jenkins_hook_url']
     else
       raise_config_error "Jenkins Hook Url not set"
     end

--- a/test/jenkins_github_test.rb
+++ b/test/jenkins_github_test.rb
@@ -16,13 +16,13 @@ class JenkinsGitHubTest < Service::TestCase
     end
 
     svc = service :push,
-      {'jenkins_hook_urls' => 'http://monkey:secret@jenkins.example.com/github-webhook/'}, payload
+      {'jenkins_hook_url' => 'http://monkey:secret@jenkins.example.com/github-webhook/'}, payload
     svc.receive_push
   end
 
   def test_push_with_multiple_endpoints
     svc = service :push,
-      {'jenkins_hook_urls' => 
+      {'jenkins_hook_url' => 
       'http://monkey:secret@jenkins.example1.com/github-webhook/ http://monkey:secret@jenkins.example2.com/github-webhook/'}, payload
 
     (1..2).each do |endpoint|
@@ -41,7 +41,7 @@ class JenkinsGitHubTest < Service::TestCase
   def test_no_jenkins_hook_url
     assert_raises Service::ConfigurationError do
       svc = service :push,
-        {'jenkins_hook_urls' => ''}, payload
+        {'jenkins_hook_url' => ''}, payload
       svc.receive_push
     end
   end


### PR DESCRIPTION
The URL input now accepts a space-separated list of end points to post to
multiple jenkins servers with each push.

Our team has two Jenkins instances and currently we can only respond to pushes on one of the servers. The other has to poll for changes. These changes would allow both to respond to pushes directly.

The docs have been updated and a test has been added to test/jenkins_github_test.rb 
