### PR TITLE
Adding JazzHub services, moving all payload processing to JazzHub

### DIFF
--- a/docs/rationaljazzhub.txt
+++ b/docs/rationaljazzhub.txt
@@ -1,0 +1,21 @@
+This service integrates github with Rational's JazzHub service (http://hub.jazz.net). The service automatically adds comments into work item specified by the commit message. Additionally, this hook allows you to create new work items from commits.
+
+Use the pattern "[#<workItemNumber>] Commit text" to add a comment to the work item with the number specified in the commit message. E.g.
+	"[#32] Fix an annoying bug."
+
+Note that the '#' is optional. 
+
+Use the pattern "[workItemType] Fix an annoying bug" to create a new work item for type workItemType. Note, that you have to enter the workItemType id instead of the name. E.g.
+	"[defect] Fox an annoying bug"
+
+This implementation supports both form based and basic authentication.
+
+Install Notes
+-------------
+
+A user with the correct licenses to add comments and create work items needs to be created. 
+
+Configuring the github hook:
+
+1. Username - This is the username of the user used to access your Rational Team Concert instance.
+2. Password - This is the password of the user used to access your Rational Team Concert instance.

--- a/lib/services/rational_jazzhub.rb
+++ b/lib/services/rational_jazzhub.rb
@@ -1,0 +1,108 @@
+class Service::RationalJazzHub < Service
+	string   :username
+	password :password
+	white_list :username
+	attr_accessor :cookies
+	attr_accessor :server_url
+
+	def receive_push
+		checkSettings
+		prepare
+		authenticate
+		postToJazzHub
+	end
+	
+	def server_url
+	    if !@server_url
+    	   if data['server_url']
+    	      @server_url = data['server_url']
+    	   else
+    	      @server_url = "https://hub.jazz.net/jts00"
+    	   end
+	    end
+    	@server_url 
+  	end
+
+	def checkSettings
+		raise_config_error "username not set" if data['username'].blank?
+		raise_config_error "password not set" if data['password'].blank?
+	end
+
+	def prepare
+#		http.ssl[:verify] = false
+		http.headers['X-com-ibm-team-userid']= data['username']
+#		http.builder.response :follow_redirects, {:cookie => :all}
+		http.builder.response :logger
+	end
+
+	def authenticate
+		form_based_authentification
+	end
+
+	def form_based_authentification
+		res= http_get '%s/authenticated/identity' % server_url
+		if not 'authrequired'.eql? res.headers['X-com-ibm-team-repository-web-auth-msg']
+			# Expect one follow for WAS login
+			if res.env[:status] == 302
+				captureCookies res
+				http.headers['Cookie']= cookieString
+				res = http_get res.env[:response_headers][:location]
+				if not 'authrequired'.eql? res.headers['X-com-ibm-team-repository-web-auth-msg']
+					raise_config_error "Invalid authentication url. The response did not include a X-com-ibm-team-repository-web-auth-msg header"
+				end
+			else
+				raise_config_error "Invalid authentication url. The response did not include a X-com-ibm-team-repository-web-auth-msg header"
+			end
+		end
+		http.headers['Cookie']= captureCookies res
+		http.headers['Content-Type']= 'application/x-www-form-urlencoded'
+
+		res= http_post '%s/authenticated/j_security_check' % server_url, 
+					   Faraday::Utils.build_nested_query(http.params.merge(:j_username => data['username'], :j_password => data['password'])) 
+
+		if 'authrequired'.eql? res.headers['X-com-ibm-team-repository-web-auth-msg']
+			raise_config_error 'Invalid Username or Password'
+		end
+	
+		http.headers['Cookie']= captureCookies res
+		http.headers['Content-Type']= ''
+		res= http_get '%s/authenticated/identity' % server_url
+		captureCookies res
+	end
+	
+	def captureCookies (response)
+		@cookies ||= Hash.new
+		setstring = response.headers['set-cookie']
+		if setstring
+	    	setstring.split(/, (?=[\w]+=)/).each { | cookie |
+   		 		# trim off the cookie domain and update info
+        		cookiepair = cookie.split('; ')[0];
+        		# split the key and value
+        		cookieparts = cookiepair.split('=')
+        		cookies[cookieparts[0]] = cookiepair[cookieparts[0].size+1..-1]
+	    	}
+        end
+    	return cookieString
+	end
+	
+	def cookieString
+		result = ''
+		if cookies 
+			cookies.each { |key, value| 
+				result += key + '=' + value + (cookies.size > 1 ? ";" : "")
+			}
+		end
+		return result
+	end
+	
+	def postToJazzHub
+		http.headers['Content-Type']= 'application/json'
+		http.headers['accept']= 'application/json'
+		
+	    res= http_post '%s/processGitHubPayload' % server_url, :payload => generate_json(payload)
+		if !res.env[:status].between(200,299)
+			raise_config_error 'Error posting payload to %s, response: %s' % ('%s/processGitHubPayload' % @server_url), res
+		end
+	end
+
+end

--- a/lib/services/rational_jazzhub_test.rb
+++ b/lib/services/rational_jazzhub_test.rb
@@ -1,0 +1,71 @@
+require File.expand_path('../helper', __FILE__)
+
+class RationalTeamConcertTest < Service::TestCase
+  def setup
+    @stubs= Faraday::Adapter::Test::Stubs.new
+
+    @stubs.post "/processGitHubPayload" do |env|
+      assert_common_headers env
+      assert_common_oslc_headers env
+      @Pushes += 1
+      [201, {}, '']
+    end
+    
+    @stubs.get "/jazz/authenticated/identity" do |env|
+      assert_common_headers env
+      cookie= env[:request_headers]['Cookie'] == nil ? cookie1 : cookie2;
+      [201, {"X-com-ibm-team-repository-web-auth-msg" => "authrequired", "set-cookie" => cookie}, '']
+    end
+    
+    @stubs.post "/jazz/authenticated/j_security_check"  do |env|
+      assert_common_headers env
+      assert_equal 'application/x-www-form-urlencoded', env[:request_headers]['Content-Type']
+      assert_equal cookie1, env[:request_headers]['Cookie']
+      [201, {}, oslc_json_response]
+    end
+  end
+
+  def test_push_updates
+    modified_payload = payload.clone()
+    modified_payload['commits'][0]['message'] << "\n[51] Some message"
+    modified_payload['commits'][1]['message'] << "\n[31] clean up "
+    modified_payload['commits'][2]['message'] << "\n[1] Closes tracker item 1"
+
+    svc = service(
+      {'server_url' => 'https://foo.com/jazz', 
+       'username' => username, 
+       'password' => password,
+       'project_area_uuid' => '_UIID',
+       'basic_authentication' => false},
+        modified_payload)
+    svc.receive_push
+
+    assert_equal 1, @Pushes
+  end
+
+  def assert_common_headers env
+    assert_equal username, env[:request_headers]['X-com-ibm-team-userid']
+    assert_equal 'foo.com', env[:url].host
+  end
+
+  def username
+    return 'test_user' 
+  end
+
+  def password
+    return 'test_pass'
+  end
+
+  def cookie1
+    return "JSESSIONID=abcd123456"
+  end
+
+  def cookie2
+    return "JSESSIONID=abcd12345678910"
+  end
+  
+  def service(*args)
+    super Service::RationalJazzHub, *args
+  end
+end
+

--- a/lib/services/rational_team_concert.rb
+++ b/lib/services/rational_team_concert.rb
@@ -12,6 +12,11 @@ class Service::RationalTeamConcert < Service
 		authenticate
 		commit_changes
 	end
+	
+	def server_url
+		#trim trailing / if provided
+    	@server_url ||= data['server_url'].gsub(/\/$/, '')
+  	end
 
 	def checkSettings
 		raise_config_error "Server Url url not set" if data['server_url'].blank?
@@ -25,6 +30,7 @@ class Service::RationalTeamConcert < Service
 			http.ssl[:verify] = false
 		end 
 		http.headers['X-com-ibm-team-userid']= data['username']
+		http.builder.response :logger
 	end
 
 	def authenticate 
@@ -36,7 +42,7 @@ class Service::RationalTeamConcert < Service
 	end
 
 	def form_based_authentification
-		res= http_get '%s/authenticated/identity' % data['server_url']
+		res= http_get '%s/authenticated/identity' % server_url
 		if not 'authrequired'.eql? res.headers['X-com-ibm-team-repository-web-auth-msg']
 			# Expect one follow for WAS login
 			if res.env[:status] == 302
@@ -53,7 +59,7 @@ class Service::RationalTeamConcert < Service
 		http.headers['Cookie']= captureCookies res
 		http.headers['Content-Type']= 'application/x-www-form-urlencoded'
 
-		res= http_post '%s/authenticated/j_security_check' % data['server_url'], 
+		res= http_post '%s/authenticated/j_security_check' % server_url, 
 					   Faraday::Utils.build_nested_query(http.params.merge(:j_username => data['username'], :j_password => data['password'])) 
 
 		if 'authrequired'.eql? res.headers['X-com-ibm-team-repository-web-auth-msg']
@@ -62,7 +68,7 @@ class Service::RationalTeamConcert < Service
 	
 		http.headers['Cookie']= captureCookies res
 		http.headers['Content-Type']= ''
-		res= http_get '%s/authenticated/identity' % data['server_url']
+		res= http_get '%s/authenticated/identity' % server_url
 		captureCookies res
 	end
 	
@@ -121,7 +127,7 @@ class Service::RationalTeamConcert < Service
 
 	def get_work_item (work_item_number)
 		http.headers['Cookie']= cookieString
-		res= http_get "%s/resource/itemName/com.ibm.team.workitem.WorkItem/%s?oslc.properties=oslc:discussedBy" % [ data['server_url'], work_item_number ]  
+		res= http_get "%s/resource/itemName/com.ibm.team.workitem.WorkItem/%s?oslc.properties=oslc:discussedBy" % [ server_url, work_item_number ]  
 		# Expect one follow for WAS login
 		if res.env[:status] == 302
 			captureCookies res
@@ -132,7 +138,7 @@ class Service::RationalTeamConcert < Service
 	end
 
 	def new_work_item (commit, work_item_type)
-		url= "%s/oslc/contexts/%s/workitems/%s" % [data['server_url'], data['project_area_uuid'], work_item_type]
+		url= "%s/oslc/contexts/%s/workitems/%s" % [server_url, data['project_area_uuid'], work_item_type]
 		work_item= { 'dcterms:title' => commit['message']}
 		http.headers['Cookie']= cookieString
 		res= http_post url, generate_json(work_item)


### PR DESCRIPTION
This hook will eventually replace the RationalTeamConcert service.

We've moved all the payload processing logic to our server, so all that's left is the authentication handling here.

Added doc, the config only requires userid and password.  There is an optional server_url parameter, which will only be used by us for testing.  I wasn't sure if there was a way to annotate that in the source.

We're really hoping to demo this at our user's conference in a week...
