### PR TITLE
correctly check send_only_ticket_commits option, likely fixes #540

### DIFF
--- a/lib/services/lighthouse.rb
+++ b/lib/services/lighthouse.rb
@@ -10,7 +10,7 @@ class Service::Lighthouse < Service
     payload['commits'].each do |commit|
       next if commit['message'] =~ /^x /
       next if data['send_only_ticket_commits'] == '1' \
-        and (commit['message'] =~ check_for_lighthouse_flags).nil?
+        && (commit['message'] =~ check_for_lighthouse_flags).nil?
 
       commit_id = commit['id']
       added     = commit['added'].map    { |f| ['A', f] }


### PR DESCRIPTION
This changes the behavior of the Lighthouse hook to check the send_only_ticket_commits flag correctly. Unfortunately I was not able to test this change because I could not get the server to run locally (see #540)
