### PR TITLE
renaming LeChat to Kato

### DIFF
--- a/docs/lechat
+++ b/docs/lechat
@@ -1,10 +1,10 @@
-LeChat
+Kato
 =====
 
-LeChat is a team chat service with an emphasis on search, user interface, and reliability.
+Kato is a team chat service with an emphasis on search, user interface, and reliability.
 
-Integrating with GitHub will cause certain information about commits, issues, and comments to appear in a specified LeChat room.
+Integrating with GitHub will cause certain information about commits, issues, and comments to appear in a specified Kato room.
 
 Install Notes
 -------------
-**Webhook Url** -  GitHub webhook URL from the Integrations tab in room settings in your [LeChat](http://lechat.im) account
+**Webhook Url** -  GitHub webhook URL from the Integrations tab in room settings in your [Kato](http://kato.im) account

--- a/lib/services/kato.rb
+++ b/lib/services/kato.rb
@@ -1,4 +1,5 @@
-class Service::LeChat < Service::HttpPost
+class Service::Kato < Service::HttpPost
+  hook_name 'lechat'
   string :webhook_url
 
   # include 'webhook_url' in the debug logs
@@ -6,11 +7,11 @@ class Service::LeChat < Service::HttpPost
 
   default_events Service::ALL_EVENTS
 
-  url "https://lechat.im/"
+  url "https://kato.im/"
 
   maintained_by :github => 'JLarky'
 
-  supported_by :email => 'support@lechat.im'
+  supported_by :email => 'support@kato.im'
 
   def receive_event
     webhook_url = required_config_value('webhook_url')

--- a/test/kato_test.rb
+++ b/test/kato_test.rb
@@ -1,10 +1,10 @@
 require File.expand_path('../helper', __FILE__)
 
-class LechatTest < Service::TestCase
+class KatoTest < Service::TestCase
   include Service::HttpTestMethods
 
   def test_push
-    host = "api.lechat.im"
+    host = "api.kato.im"
     path = "/rooms/ca584f3e2143a0c3eae7a89485aa7f634589ceb39c972361bdefe348812794b1/github"
 
     data = {
@@ -30,7 +30,7 @@ class LechatTest < Service::TestCase
   end
 
   def service_class
-    Service::LeChat
+    Service::Kato
   end
 end
 


### PR DESCRIPTION
LeChat was renamed to Kato (http://kato.quora.com/Au-Revoir-LeChat-Saluton-Kat%C5%8D) so we need to rename service too, hopefully saving all existing integrations by using 'hook_name'.
