### PR TITLE
Remove the explicit color codes for push notice's square brackets

### DIFF
--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -219,7 +219,7 @@ class Service::IRC < Service
 
   def irc_push_summary_message
     message = []
-    message << "\00301[#{fmt_repo repo_name}\00301] #{fmt_name pusher_name}"
+    message << "[#{fmt_repo repo_name}] #{fmt_name pusher_name}"
 
     if created?
       if tag?


### PR DESCRIPTION
This reverts commit 62ab026d9e48f43f879623b08155276be8347d96.

The brackets were not shown on the **black** background.
#467 says "the closing bracket being bright pink". But, it doesn't seem to be true because there exists the explicit reset code(\017) at the end of fmt_repo. (https://github.com/github/github-services/blob/62ab026d9e48f43f879623b08155276be8347d96/services/irc.rb#L153)

In addition, other messages(issue, commit, pull request) don't have the explicit color codes for their brackets.
See https://github.com/github/github-services/blob/5f99fde524bf59d602c677faa8217bd533cac690/lib/services/irc.rb#L276 (also #L284, #L293, #L303, #L313 in the same file)
