### PR TITLE
Adding support for Hakiri service (www.hakiriup.com).

### DIFF
--- a/docs/hakiri
+++ b/docs/hakiri
@@ -1,0 +1,19 @@
+This service posts an event object for Github pushed to Hakiri.
+Hakiri checks if your repo was updated with a new commit and then runs security tests on it.
+
+Supported events are currently:
+'push'
+
+Data:
+'event' - The GitHub event type, eg. 'push' for commits.
+'payload' - The data for the push.
+
+More details on Github events: http://developer.github.com/v3/repos/hooks/
+
+Install Notes
+------------
+
+Project ID: generated whenever new project is created. You can locate it in the address bar
+Token: each project repository has a security token.
+
+See https://www.hakiriup.com/docs/getting-started for more docs.

--- a/lib/services/hakiri.rb
+++ b/lib/services/hakiri.rb
@@ -1,0 +1,35 @@
+require_relative './http_post'
+
+class Service::Hakiri < Service::HttpPost
+  string :token, :project_id
+
+  white_list :project_id
+
+  default_events :push
+
+  url 'https://www.hakiriup.com'
+  logo_url 'http://files.hakiriup.com.s3.amazonaws.com/images/logo-small.png'
+
+  maintained_by :github => 'vasinov',
+                :twitter => '@vasinov'
+
+  supported_by :web => 'https://www.hakiriup.com',
+               :email => 'info@hakiriup.com',
+               :twitter => '@vasinov'
+
+  def receive_event
+    token = required_config_value('token')
+    project_id = required_config_value('project_id')
+
+    if token.match(/^[A-Za-z0-9]+$/) == nil
+      raise_config_error 'Invalid token'
+    end
+
+    if project_id.match(/^[0-9]+$/) == nil
+      raise_config_error 'Invalid project ID'
+    end
+
+    url = "https://www.hakiriup.com/projects/#{project_id}/repositories/github_push?repo_token=#{token}"
+    deliver url
+  end
+end

--- a/test/hakiri_test.rb
+++ b/test/hakiri_test.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../helper', __FILE__)
+
+class HakiriTest < Service::TestCase
+  include Service::HttpTestMethods
+
+  def test_push
+    test_project_id = '1'
+    test_token = '0123456789abcde'
+
+    data = {
+        'project_id' => test_project_id,
+        'token' => test_token
+    }
+
+    payload = { 'commits' => [{ 'id'=>'test' }] }
+    svc = service(data, payload)
+
+    @stubs.post "/projects/#{test_project_id}/repositories/github_push?repo_token=#{test_token}" do |env|
+      body = JSON.parse(env[:body])
+
+      assert_equal env[:url].host, 'www.hakiriup.com'
+      assert_equal 'test', body['payload']['commits'][0]['id']
+      assert_equal data, body['config']
+      assert_equal 'push', body['event']
+      [200, {}, '']
+    end
+
+    svc.receive_event
+    @stubs.verify_stubbed_calls
+  end
+
+  def service_class
+    Service::Hakiri
+  end
+end
+


### PR DESCRIPTION
Hakiri is the Rails security platform. Developers using Hakiri can hook up their GitHub repos and when a new push is initiated this service makes a request to Hakiri to let the project know that there was a push. 
