### PR TITLE
Subscribe tenXer to all events by default.

### DIFF
--- a/lib/services/tenxer.rb
+++ b/lib/services/tenxer.rb
@@ -7,6 +7,8 @@ class Service::Tenxer < Service
   supported_by :web => 'http://www.tenxer.com/faq',
     :email => 'support@tenxer.com'
 
+  default_events Service::ALL_EVENTS
+
   def receive_event
     url = "https://www.tenxer.com/updater/githubpubsubhubbub/"
     res = http_post url, {'payload' => generate_json(payload)},


### PR DESCRIPTION
We had indicated that we supported all events, but not that we wished to subscribe to them.
