### PR TITLE
Update the Coffeedoc.info service hook to the new payload format.

### DIFF
--- a/lib/services/coffeedocinfo.rb
+++ b/lib/services/coffeedocinfo.rb
@@ -1,16 +1,17 @@
-class Service::CoffeeDocInfo < Service
+class Service::CoffeeDocInfo < Service::HttpPost
   self.title = 'CoffeeDoc.info'
 
   default_events :push
 
   url "http://coffeedoc.info/"
 
-  maintained_by :github => 'pwnall'
+  maintained_by :github => 'pwnall', :twitter => '@pwnall'
 
   supported_by :web => 'https://github.com/netzpirat/coffeedoc.info',
                :twitter => 'netzpirat', :github => 'netzpirat'
 
-  def receive_push
-    http_post 'http://coffeedoc.info/checkout', :payload => generate_json(payload)
+  def receive_event
+    url = 'http://coffeedoc.info/checkout'
+    deliver url
   end
 end

--- a/test/coffeedocinfo_test.rb
+++ b/test/coffeedocinfo_test.rb
@@ -1,24 +1,25 @@
 require File.expand_path('../helper', __FILE__)
 
 class CoffeeDocInfoTest < Service::TestCase
-  def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-  end
+  include Service::HttpTestMethods
 
   def test_push
     @stubs.post "/checkout" do |env|
       assert_equal 'coffeedoc.info', env[:url].host
-      data = Faraday::Utils.parse_query(env[:body])
-      assert_equal 1, JSON.parse(data['payload'])['a']
+      body = JSON.parse(env[:body])
+      assert_equal 'push', body['event']
+      assert_equal 'test', body['payload']['commits'][0]['id']
       [200, {}, '']
     end
 
-    svc = service({}, :a => 1)
-    svc.receive_push
+    payload = {'commits'=>[{'id'=>'test'}]}
+    svc = service({}, payload)
+    svc.receive_event
+    @stubs.verify_stubbed_calls
   end
 
-  def service(*args)
-    super Service::CoffeeDocInfo, *args
+  def service_class
+    Service::CoffeeDocInfo
   end
 end
 


### PR DESCRIPTION
coffeedoc.info docs stopped updating when the service hook is used. However, if http://coffeedoc.info/checkout is used as a WebHook URL, the docs update.

This PR updates the service code using the recommended Simperium example.
