### PR TITLE
Add a 'pull requests only' option to the IRC hook

### DIFF
--- a/docs/irc
+++ b/docs/irc
@@ -7,13 +7,14 @@
 5.  `nick` - Nickname for the bot (optional)
 6.  `nickserv_password` - Password for the server's [NickServ](http://en.wikipedia.org/wiki/Internet_Relay_Chat_services) (optional)
 7.  `long_url` - Displays full compare/commit url's. Uses git.io if disabled.
-8.  `message_without_join` - Prevents join/part spam by the bot. See step 13.
+8.  `message_without_join` - Prevents join/part spam by the bot. See step 14.
 9.  `no_colors` - Disables color support for messages.
 10.  `notice` - Sends as a notice rather than a channel message.
 11. `branch_regexes` - Regular expressions for branch name matching (optional, comma separated).
      For example, only master => `^master$`, master & starts with bug => `master,^bug`.
-12. `active` - Activates the bot.
-13. Configure your IRC channel to allow external messages, necessary for the `message_without_join` option.
+12.  `pull_requests_only` - Only notify about pull requests (open, merge, close).
+13. `active` - Activates the bot.
+14. Configure your IRC channel to allow external messages, necessary for the `message_without_join` option.
     `/mode #channelname -n` or `/msg chanserv set #channelname mlock -n`
 
 Here's an example for Freenode:

--- a/test/irc_test.rb
+++ b/test/irc_test.rb
@@ -200,6 +200,14 @@ class IRCTest < Service::TestCase
     assert_nil msgs.shift
   end
 
+  def test_push_with_pull_requests_only
+    svc = service({'room' => 'r', 'nick' => 'n', 'pull_requests_only' => '1'}, payload)
+    
+    svc.receive_push
+    msgs = svc.writable_irc.string.split("\n")
+    assert_nil msgs.shift
+  end
+
   def test_commit_comment
     svc = service(:commit_comment, {'room' => 'r', 'nick' => 'n'}, commit_comment_payload)
 
@@ -214,9 +222,31 @@ class IRCTest < Service::TestCase
     assert_nil msgs.shift
   end
 
+  def test_commit_comment_with_pull_requests_only
+    svc = service(:commit_comment, {'room' => 'r', 'nick' => 'n', 'pull_requests_only' => '1'}, commit_comment_payload)
+    
+    svc.receive_commit_comment
+    msgs = svc.writable_irc.string.split("\n")
+    assert_nil msgs.shift
+  end
+
   def test_pull_request
     svc = service(:pull_request, {'room' => 'r', 'nick' => 'n'}, pull_payload)
 
+    svc.receive_pull_request
+    msgs = svc.writable_irc.string.split("\n")
+    assert_equal "NICK n", msgs.shift
+    assert_match "USER n", msgs.shift
+    assert_equal "JOIN #r", msgs.shift.strip
+    assert_match /PRIVMSG #r.*grit/, msgs.shift
+    assert_equal "PART #r", msgs.shift.strip
+    assert_equal "QUIT", msgs.shift.strip
+    assert_nil msgs.shift
+  end
+
+  def test_pull_request_with_pull_requests_only
+    svc = service(:pull_request, {'room' => 'r', 'nick' => 'n', 'pull_requests_only' => '1'}, pull_payload)
+    
     svc.receive_pull_request
     msgs = svc.writable_irc.string.split("\n")
     assert_equal "NICK n", msgs.shift
@@ -242,6 +272,14 @@ class IRCTest < Service::TestCase
     assert_nil msgs.shift
   end
 
+  def test_issues_with_pull_requests_only
+    svc = service(:issues, {'room' => 'r', 'nick' => 'n', 'pull_requests_only' => '1'}, issues_payload)
+
+    svc.receive_issues
+    msgs = svc.writable_irc.string.split("\n")
+    assert_nil msgs.shift
+  end
+
   def test_issue_comment
     svc = service(:issue_comment, {'room' => 'r', 'nick' => 'n'}, issue_comment_payload)
 
@@ -256,6 +294,14 @@ class IRCTest < Service::TestCase
     assert_nil msgs.shift
   end
 
+  def test_issue_comment_with_pull_requests_only
+    svc = service(:issue_comment, {'room' => 'r', 'nick' => 'n', 'pull_requests_only' => '1'}, issue_comment_payload)
+
+    svc.receive_issue_comment
+    msgs = svc.writable_irc.string.split("\n")
+    assert_nil msgs.shift
+  end
+
   def test_pull_request_review_comment
     svc = service(:pull_request_review_comment, {'room' => 'r', 'nick' => 'n'}, pull_request_review_comment_payload)
 
@@ -267,6 +313,14 @@ class IRCTest < Service::TestCase
     assert_match /PRIVMSG #r.*grit.*pull request #5 /, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
     assert_equal "QUIT", msgs.shift.strip
+    assert_nil msgs.shift
+  end
+
+  def test_issues_with_pull_requests_only
+    svc = service(:pull_request_review_comment, {'room' => 'r', 'nick' => 'n', 'pull_requests_only' => '1'}, pull_request_review_comment_payload)
+
+    svc.receive_pull_request_review_comment
+    msgs = svc.writable_irc.string.split("\n")
     assert_nil msgs.shift
   end
 


### PR DESCRIPTION
This allows quieter channels to avoid too much traffic from pushes and comments, and just keep the important PR notifications.
