### PR TITLE
JIRA resolution key should use hash as value, with 'ID' key being set

### DIFF
--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -24,7 +24,7 @@ class Service::Jira < Service
         if key =~ /(?i)status|(?i)transition/
           changeset.merge!(:transition => value.to_s)
         elsif key =~ /(?i)resolution/
-          changeset.merge!(:fields => { :resolution => value.to_s })
+          changeset.merge!(:fields => { :resolution => { :id => value.to_s } })
         else
           changeset.merge!(:fields => { key.to_sym => "Resolved" })
         end


### PR DESCRIPTION
According to the API documentation (specifically https://docs.atlassian.com/jira/REST/latest/#idp1798112), `resolution` needs to have its own set of fields posted, either an ID or name. Given that the transition uses ID, this uses resolution ID as well.
