### PR TITLE
docs/irc: s/Freenode/freenode/

### DIFF
--- a/docs/irc
+++ b/docs/irc
@@ -1,6 +1,6 @@
 1.  `server` - IRC server (e.g. irc.freenode.net)
 2.  `port` - The port to connect to the server (optional). Default values: 6667 (No SSL) when `Ssl` not checked, 9999 (SSL) when `Ssl` is checked.
-     Freenode servers listen on ports 6665, 6666, 6667, 6697 (SSL only), 7000 (SSL only), 7070 (SSL only), 8000, 8001 and 8002.
+     freenode servers listen on ports 6665, 6666, 6667, 6697 (SSL only), 7000 (SSL only), 7070 (SSL only), 8000, 8001 and 8002.
 3.  `room` - Supports single or multiple rooms (comma separated).
      Also supports room passwords (room_name::password). Prefixing '#' to the room is optional.
 4.  `password` - Server password (optional)
@@ -16,7 +16,7 @@
 13. Configure your IRC channel to allow external messages, necessary for the `message_without_join` option.
     `/mode #channelname -n` or `/msg chanserv set #channelname mlock -n`
 
-Here's an example for Freenode:
+Here's an example for freenode:
 
     # server: irc.freenode.net
     # port: 6667


### PR DESCRIPTION
It's lower case. Always.
