### PR TITLE
Allow Service::HttpPost to be registered

### DIFF
--- a/lib/services/http_post.rb
+++ b/lib/services/http_post.rb
@@ -1,6 +1,4 @@
 class Service::HttpPost < Service
-  Service.services.delete(self)
-
   include HttpHelper
 
   alias receive_event deliver
@@ -15,4 +13,3 @@ class Service::HttpPost < Service
      :guid => delivery_guid}
   end
 end
-


### PR DESCRIPTION
This removes the deletion of `HttpPost` from the registry so we can directly access HttpPost within our delivery mechanism.
