### PR TITLE
Set content-type to application json for ontime 13.3 or greater

### DIFF
--- a/lib/services/ontime.rb
+++ b/lib/services/ontime.rb
@@ -29,6 +29,11 @@ class Service::OnTime < Service
       raise_config_error "Unexpected API version. Please update to the latest version of OnTime to use this service."
     end
 
+    if (version['major'] == 13 and version['minor'] >= 3  or version['major'] > 13)
+      #Versions prior to 13.3 expect encoded form data (the default), not json.
+      http.headers['Content-Type'] = 'application/json'
+    end
+
     verify_response(result)
   end
 


### PR DESCRIPTION
The new version of the OnTime APIs (starting with 13.3) accept content-type application/json rather than encoded form data. Modified the service to update the content-type header when version is GTE 13.3. Otherwise leaves the data alone. 
