### PR TITLE
IronWorker: changed queue_name to code_name

### DIFF
--- a/lib/services/iron_worker.rb
+++ b/lib/services/iron_worker.rb
@@ -1,8 +1,8 @@
 class Service::IronWorker < Service::HttpPost
   string :token
   string :project_id
-  string :queue_name
-  white_list :project_id, :queue_name
+  string :code_name
+  white_list :project_id, :code_name
 
   default_events :commit_comment, :download, :fork, :fork_apply, :gollum,
                  :issues, :issue_comment, :member, :public, :pull_request, :push, :watch


### PR DESCRIPTION
Fixing a small typo. Doesn't change underlying functionality, and tests continue to pass with the modification.

``` sh
$ ruby -itest test/iron_worker_test.rb 
Run options: 

# Running tests:

...

Finished tests in 0.007968s, 376.5060 tests/s, 502.0080 assertions/s.

3 tests, 4 assertions, 0 failures, 0 errors, 0 skips
```
