### PR TITLE
Don't bother setting keys to empty values.

### DIFF
--- a/lib/service.rb
+++ b/lib/service.rb
@@ -354,7 +354,8 @@ class Service
         hash = (File.exist?(email_config_file) && YAML.load_file(email_config_file)) || {}
         EMAIL_KEYS.each do |key|
           env_key = "EMAIL_SMTP_#{key.upcase}"
-          if value = ENV[env_key]
+          value = ENV[env_key]
+          if value && value != ''
             hash[key] = value
           end
         end


### PR DESCRIPTION
This can cause problems when Net::SMTP#start is passed empty strings as values in place of nil. This can trigger the authentication check exception when the user / password is an empty string.

Does this seem sane? 

/cc @technoweenie @benburkert 
