### PR TITLE
Accurate line numbers in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Other hook types
 
 The default hook for a service is `push`. You may wish to have services respond
 to other event types, like `pull_request` or `issues`. The full list may be
-found in [service.rb](https://github.com/github/github-services/blob/master/lib/service.rb#L78).
+found in [service.rb](https://github.com/github/github-services/blob/master/lib/service.rb#L79-L83).
 Unless your service specifies `default_events <list_of_types>`, only the `push`
 hook will be called, see
 [service.rb#default_events](https://github.com/github/github-services/blob/55a1fb10a44a80dec6a744d0828c769b00d97ee2/lib/service.rb#L122-L133).


### PR DESCRIPTION
The reference to the list of events that can trigger a response was off by a line. This pull request corrects that and highlights the entire relevant section of code.
