### PR TITLE
Send delivery_guid as a header in Travis service

### DIFF
--- a/lib/services/travis.rb
+++ b/lib/services/travis.rb
@@ -9,6 +9,7 @@ class Service::Travis < Service
     http.ssl[:verify] = false
     http.basic_auth user, token
     http.headers['X-GitHub-Event'] = event.to_s
+    http.headers['X-GitHub-GUID'] = delivery_guid.to_s
     http_post travis_url, :payload => generate_json(payload)
   end
 

--- a/test/travis_test.rb
+++ b/test/travis_test.rb
@@ -4,6 +4,7 @@ class TravisTest < Service::TestCase
   def setup
     @stubs = Faraday::Adapter::Test::Stubs.new
     @svc   = service(basic_config, push_payload)
+    @svc.delivery_guid = 'guid-123'
   end
 
   def test_reads_user_from_config
@@ -38,6 +39,7 @@ class TravisTest < Service::TestCase
       assert_equal basic_auth('kronn', '5373dd4a3648b88fa9acb8e46ebc188a'),
         env[:request_headers]['authorization']
       assert_equal 'push', env[:request_headers]['x-github-event']
+      assert_equal 'guid-123', env[:request_headers]['x-github-guid']
       assert_equal payload, JSON.parse(Faraday::Utils.parse_query(env[:body])['payload'])
     end
     @svc.receive_event


### PR DESCRIPTION
This PR adds `delivery_guid` as `X-Github-GUID`, following the convention of putting the extra info in headers and using the untouched event payload.
