### PR TITLE
updating delivery URL, missing .php extension was preventing POST's from being processed

### DIFF
--- a/lib/services/namecast.rb
+++ b/lib/services/namecast.rb
@@ -14,7 +14,7 @@ class Service::Namecast < Service::HttpPost
     :twitter => '@Namecast'
 
   def receive_event
-    deliver "https://www.namecast.net/hooks/dnssync"
+    deliver "https://www.namecast.net/hooks/dnssync.php"
   end
 end
 


### PR DESCRIPTION
Didn't catch this initally during testing, but can confirm in our dev and prod environments  by testing the webhook URL manually with and without the extension.
