### PR TITLE
Update Web service to listen to all events

### DIFF
--- a/lib/services/web.rb
+++ b/lib/services/web.rb
@@ -17,6 +17,8 @@ class Service::Web < Service
 
   boolean :insecure_ssl # :(
 
+  default_events Service::ALL_EVENTS
+
   def receive_event
     http.headers['X-GitHub-Event'] = event.to_s
     http.headers['X-GitHub-Delivery'] = delivery_guid.to_s

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -5,6 +5,10 @@ class WebTest < Service::TestCase
     @stubs = Faraday::Adapter::Test::Stubs.new
   end
 
+  def test_listens_to_all_events
+    assert_equal Service::ALL_EVENTS, Service::Web.default_events
+  end
+
   def test_push
     svc = service({
       'url' => 'http://monkey:secret@abc.com/foo/?a=1',
@@ -102,6 +106,19 @@ class WebTest < Service::TestCase
                                         'monkey', env[:body]),
         env[:request_headers]['X-Hub-Signature']
       assert_equal payload, JSON.parse(env[:body])
+      [200, {}, '']
+    end
+
+    svc.receive_event
+  end
+
+  def test_issue
+    svc = service(:issue, {
+      'url' => 'http://abc.com/bar/'
+    }, issues_payload)
+
+    @stubs.post "/bar/" do |env|
+      assert_equal 'issue', env[:request_headers]['x-github-event']
       [200, {}, '']
     end
 


### PR DESCRIPTION
# Problem

This updates `Services::Web` to listen to all system events by default to bring the expected behavior in line with the documentation. From the [repo hooks docs](http://developer.github.com/v3/repos/hooks/) (emphasis mine):

> For a Hook to go through, the Hook needs to be configured to trigger for an event, and the Service has to listen to it. Most of the Services only listen for push events. **However, the generic Web Service listens for all events.**

In testing with RequestBin we found the actual behavior of the web service to only listen for `push` events. This observation is backed up with the [JSON hook representation](https://api.github.com/hooks) (seen below), where the only event listed is `push`:

``` json
{
    name: "web",
    events: [
        "push"
    ],
    supported_events: [
        "commit_comment",
        "create",
        "delete",
        "download",
        "follow",
        "fork",
        "fork_apply",
        "gist",
        "gollum",
        "issue_comment",
        "issues",
        "member",
        "public",
        "pull_request",
        "pull_request_review_comment",
        "push",
        "status",
        "team_add",
        "watch"
    ],
    schema: [
        [
            "string",
            "url"
        ],
        [
            "string",
            "secret"
        ],
        [
            "string",
            "content_type"
        ],
        [
            "string",
            "ssl_version"
        ],
        [
            "boolean",
            "insecure_ssl"
        ]
    ]
}
```
# Fix

Added `Service::ALL_EVENTS` as the `default_events` so the web services would listen for all supported events.
# Tests

Expanded test coverage for the types of events that are listened to and a single test for an event other than `push`.
- Added a test to ensure the services listens to all events by comparing `Service::ALL_EVENTS` to the `default_events`
- Added an `issue` test to make sure the payload comes through as expected.
