### PR TITLE
EMAIL_SMTP_ENABLE_STARTTLS_AUTO is the string 'false' not a false value

### DIFF
--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -139,7 +139,7 @@ class Service::Email < Service
   end
 
   def smtp_enable_starttls_auto?
-    @smtp_enable_starttls_auto ||= (email_config['enable_starttls_auto'] && true)
+    @smtp_enable_starttls_auto ||= (email_config['enable_starttls_auto'] != 'false' && true)
   end
 
   def smtp_openssl_verify_mode


### PR DESCRIPTION
Enterprise customers currently are unable to disable TLS since we are setting the environment variable to the string false.
