### PR TITLE
- support for Open Build Service (OBS) instances

### DIFF
--- a/docs/obs
+++ b/docs/obs
@@ -1,0 +1,31 @@
+Open Build Service(OBS) is a distribution build system.
+
+By enabling this hook, any Open Build Service instance (running version 2.5 or higher) will list
+to push events. OBS Source Service will get execute for a defined package which will update
+the sources in OBS and therefore rebuild automatically.
+
+Install Notes
+-------------
+
+0. Prequire
+   You need to have a package using a source service to update the sources.
+   Check the OBS manual how to set this up.
+
+1.  Create an authentification token for your account using "osc" commandline tool:
+    # osc token --create
+
+    You may already specify the package here
+    # osc token --create <PROJECT> <PACKAGE>
+
+    That means the token can only be used for this package. It also means you do not have
+    to specify it in github.com. Just using the token is enough.
+
+2.  Enter your credentials at github.com
+    - The token which got created (use "osc token" if you lost it)
+    - optional: Modify the api url, if you do not use the openSUSE Build Service instance.
+    - optional: Enter the project and package name in case you have a generic token.
+
+3.  Make sure the "Active" checkbox is ticked, and click "Update Settings".
+
+For more details about OBS, go to http://www.openbuildservice.org
+

--- a/lib/services/obs.rb
+++ b/lib/services/obs.rb
@@ -1,0 +1,40 @@
+class Service::Obs < Service::HttpPost
+  string :url, :token, :project, :package
+
+  white_list :url, :project, :package
+
+  default_events :push
+
+  url "https://build.opensuse.org"
+  logo_url "https://github.com/openSUSE/obs-landing/blob/gh-pages/images/obs-logo.png"
+
+  maintained_by :github => 'adrianschroeter'
+
+  supported_by :web => 'https://www.openbuildservice.org/support/',
+    :email => 'buildservice-opensuse@opensuse.org'
+
+  def receive_push
+    # required
+    token = required_config_value('token')
+    url = config_value('url')
+    url = "https://api.opensuse.org:443" if url.blank?
+
+    # optional. The token may set the package container already.
+    project = config_value('project')
+    package = config_value('package')
+
+    if token.match(/^[A-Za-z0-9+\/=]+$/) == nil
+      # token is not base64
+      raise_config_error "Invalid token"
+    end
+
+    http.ssl[:verify] = false
+    http.headers['Authorization'] = "Token #{token}"
+
+    url = "#{url}/trigger/runservice"
+    unless project.blank? or package.blank?
+      url << "?project=#{CGI.escape(project)}&package=#{CGI.escape(package)}"
+    end
+    deliver url
+  end
+end

--- a/test/obs_test.rb
+++ b/test/obs_test.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../helper', __FILE__)
+
+class ObsTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def data
+    {
+      # service works with all current OBS 2.5 instances
+      "url" => "http://api.opensuse.org:443",
+      "token" => "github/test/token/string",
+      # optional
+      "project" => "home:adrianSuSE",
+      "package" => "4github",
+    }
+  end
+
+  def test_push
+    apicall = "/trigger/runservice"
+    @stubs.post apicall do |env|
+      assert_equal 'api.opensuse.org', env[:url].host
+      params = Faraday::Utils.parse_query env[:body]
+      assert_equal 'Token github/test/token/string', env[:request_headers]["Authorization"]
+      assert_equal '/trigger/runservice', env[:url].path
+      assert_equal 'project=home%3AadrianSuSE&package=4github', env[:url].query
+      [200, {}, '']
+    end
+
+    svc = service :push, data, payload
+    svc.receive
+  end
+
+  def service(*args)
+    super Service::Obs, *args
+  end
+end
+


### PR DESCRIPTION
Initial code for OBS integration. api.opensuse.org is not yet deployed (hopefully next week), but api-test.opensuse.org as used in the test case is working already
