### PR TITLE
Force a specific SSL version for SnowyEvening

### DIFF
--- a/lib/services/snowyevening.rb
+++ b/lib/services/snowyevening.rb
@@ -2,6 +2,7 @@ class Service::SnowyEvening < Service
   string :project, :api_key
 
   def receive_push
+  	http.ssl[:version] = :sslv3
     http.ssl[:verify] = false
     res = http_post "https://snowy-evening.com/api/integration/github_commit/"+data['api_key']+"/"+data['project'],
       :payload => generate_json(payload)


### PR DESCRIPTION
This will make Snowy Evening use a specific SSL version when communicating with their server.
