### PR TITLE
Small change in docu. Extend Service::HttpPost instead of Service.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ active contributor to the hook file itself.
 You can annotate this directly in the hook like so:
 
 ```ruby
-class Service::MyService < Service
+class Service::MyService < Service::HttpPost
   string :project, :api_token
 
   # only include 'project' in the debug logs, skip the api token.


### PR DESCRIPTION
I found this part in the documentation confusing. 
