### PR TITLE
ignore more ruby management artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ docs/payload_data
 log
 tmp
 pkg
+.ruby-gemset
 .ruby-version


### PR DESCRIPTION
This is a generated file from RVM, and since it has no use beyond a
developer's workstation, it is not needed.
