### PR TITLE
Fix truthiness check on the "port" field in the IRC service hook

### DIFF
--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -179,7 +179,7 @@ class Service::IRC < Service
   end
 
   def port
-    data['port'] ? data['port'].to_i : default_port
+    data['port'].to_i > 0 ? data['port'].to_i : default_port
   end
 
   def url

--- a/test/irc_test.rb
+++ b/test/irc_test.rb
@@ -279,7 +279,12 @@ class IRCTest < Service::TestCase
     svc = service({'ssl' => '0'}, payload)
     assert_equal 6667, svc.port
   end
-  
+
+  def test_default_port_with_empty_string
+    svc = service({'port' => ''}, payload)
+    assert_equal 6667, svc.port
+  end
+
   def test_overridden_port
     svc = service({'port' => '1234'}, payload)
     assert_equal 1234, svc.port


### PR DESCRIPTION
Empty strings are truthy and may be passed as a payload in production and would be converted to 0, resulting in a non-working default port. The tests passed when nil was used in the test environment.

I believe this will fix a problem I've run into where unspecified default ports seem to prevent the IRC service hook from working correctly.
