### PR TITLE
Add deployment events to list of all events

### DIFF
--- a/lib/service.rb
+++ b/lib/service.rb
@@ -79,7 +79,7 @@ class Service
   ALL_EVENTS = %w[
     commit_comment create delete download follow fork fork_apply gist gollum
     issue_comment issues member public pull_request push team_add watch
-    pull_request_review_comment status release
+    pull_request_review_comment status release deployment deployment_status
   ].sort
 
   class << self


### PR DESCRIPTION
This adds the `deployment` and `deployment_status` events from the recently introduced Deployments API to the list of all events.

cc @atmos 
