### PR TITLE
Email hook: add branch name to subject line

### DIFF
--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -178,9 +178,9 @@ class Service::Email < Service
     # Public
     def mail_subject
       if first_commit
-        "[#{name_with_owner}] #{first_commit_sha.slice(0, 6)}: #{first_commit_title}"
+        "[#{repository_name}] [#{branch_ref}] #{first_commit_sha.slice(0, 6)}: #{first_commit_title}"
       else
-        "[#{name_with_owner}]"
+        "[#{repository_name}]"
       end
     end
 
@@ -202,7 +202,6 @@ class Service::Email < Service
 
     def repository_text
       align(<<-EOH)
-        Branch: #{branch_ref}
         Home:   #{repo_url}
       EOH
     end

--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -180,7 +180,7 @@ class Service::Email < Service
       if first_commit
         "[#{repository_name}] [#{branch_ref}] #{first_commit_sha.slice(0, 6)}: #{first_commit_title}"
       else
-        "[#{repository_name}]"
+        "[#{repository_name}] [#{branch_ref}]"
       end
     end
 


### PR DESCRIPTION
And also change the `[Owner/Repo]` prefix to just `[Repo]`,
to be consistent with regular GitHub notifications.

Implements issue #153.