### PR TITLE
fixup twitter ssl issues, maybe

### DIFF
--- a/lib/services/twitter.rb
+++ b/lib/services/twitter.rb
@@ -84,6 +84,6 @@ class Service::Twitter < Service
 
   def consumer
     @consumer ||= ::OAuth::Consumer.new(consumer_key, consumer_secret,
-                                        {:site => "http://api.twitter.com"})
+                                        {:site => "https://api.twitter.com"})
   end
 end


### PR DESCRIPTION
It looks like posting broke sometime between January 7th and now. I found this on twitter's site https://dev.twitter.com/discussions/24239 which says we need to now use ssl.

This updates the twitter gem to use https://api.twitter.com.
