### PR TITLE
Update Trac instructions. Fix #794.

### DIFF
--- a/docs/trac
+++ b/docs/trac
@@ -2,6 +2,6 @@ This service is deprecated. To integrate GitHub with Trac, follow the
 instructions at: http://github.com/aaugustin/trac-github
 
 If you're currently relying on this service, please consider upgrading to
-trac-github. It uses a standard Webhook to provide the same features and it's
+trac-github. It uses a standard webhook to provide the same features and it's
 more actively maintained.
 


### PR DESCRIPTION
This commit doesn't touch trac.rb to avoid breaking existing installations of http://github.com/davglass/github-trac. trac-github is recommended for new installations.
