### PR TITLE
add ability to disable processing of not distinct commits

### DIFF
--- a/docs/youtrack
+++ b/docs/youtrack
@@ -3,7 +3,7 @@
   - Requires YouTrack version 2.0 or above. YouTrack Energy EAP builds are
     supported as well.
 
-  - Your YouTrack server should be acessible from the internet.
+  - Your YouTrack server should be accessible from the internet.
 
   - REST API must be enabled in your YouTrack server.
 
@@ -24,3 +24,6 @@
 
   - Branch names to track separated by space. If branches are provided, only commits to those branches will trigger
     YouTrack commands and commits to others will be ignored. If the branch field is left empty, commits on any branch will trigger commands.
+
+  - If only distinct commits should be processed. If this setting is false, same commit may be processed several times
+    (for example, when branches are merged)

--- a/lib/services/you_track.rb
+++ b/lib/services/you_track.rb
@@ -1,5 +1,6 @@
 class Service::YouTrack < Service
   string :base_url, :committers, :username, :branch
+  boolean :process_distinct
   password :password
   white_list :base_url, :username, :committers, :branch
 
@@ -51,6 +52,10 @@ class Service::YouTrack < Service
 
   def process_commit(commit)
     author = nil
+
+    #If only distinct commits should be processed, check this
+    return unless commit['distinct'] or !(data['process_distinct'])
+
     commit['message'].split("\n").each { |commit_line|
       issue_id = commit_line[/( |^)#(\w+-\d+)\b/, 2]
       next if issue_id.nil?


### PR DESCRIPTION
Added option process_distinct, that shows, if only distinct commits should be processed. This allows to avoid applying one command to issue several times. 
Also tests for this new feature were added
