### PR TITLE
Update text for Travis CI

### DIFF
--- a/docs/travis
+++ b/docs/travis
@@ -1,19 +1,13 @@
-Travis CI is a distributed build platform for the open source community.
+# Travis CI
+Travis CI is a distributed continuous integration service.
 
-By enabling this hook, Travis CI will listen to push and pull request events to trigger new builds, member and public events to keep track of repository visibility and issue comment events to allow users to talk to [@travisbot](https://github.com/travisbot).
+By enabling this hook, Travis CI will listen to push and pull request events to trigger new builds.
 
-Install Notes
--------------
+For more details about Travis, go to http://docs.travis-ci.com.
 
-We recommend using the Travis profile page at http://travis-ci.org/profile to manage your hooks.
+## Automatic configuration from Travis CI
+We recommend using the Travis profile page at https://travis-ci.org/profile to manage your hooks.
+For private repositories, use https://travis-ci.com/profile.
 
-1.  Create an account at http://travis-ci.org (you can sign in with GitHub)
-2.  Enter your credentials
-    - The token which you can find on the Travis profile page
-    - optional: Enter the username who the Travis token belongs to (defaults to the repository owner)
-    - optional: Enter the host of your Travis installation (defaults to http://notify.travis-ci.org), the protocol-prefix is optional and defaults to "http://".
-3.  Make sure the "Active" checkbox is ticked, and click "Update Settings".
-4.  Click on the "Travis" service name and then click the "Test Hook" link.
-5.  You should receive an email from Travis once the build has completed
-
-For more details about Travis, go to http://about.travis-ci.org/docs/
+## Travis CI Status
+Travis CI status page: http://status.travis-ci.com


### PR DESCRIPTION
With this major revision, we now direct user to our
setup page, so the hooks can be set up with ease.
