### PR TITLE
Turns off Amazon SNS test which relies on valid AWS creds

### DIFF
--- a/test/amazon_sns_test.rb
+++ b/test/amazon_sns_test.rb
@@ -25,7 +25,7 @@ class AmazonSNSTest < Service::TestCase
     }
   end
 
-  def test_event
+  def xtest_event
     svc = service :push, data, payload
     sns = svc.receive_event
 


### PR DESCRIPTION
This turns off the test that has been failing for the last week. Looks like the AWS creds the test relies on are no long valid. There are creds in the [SQS test](https://github.com/github/github-services/blob/master/test/sqs_queue_test.rb#L12-L13) that we might be able to use if they aren't limited to the SQS service.

It's probably better to pull out AWS creds for testing into a single config file. We could use IAM to restrict the keys to only performing actions needed by the tests.

Hopefully we can get some valid creds in here sometime to turn this back on. Or, figure out a way to test this in isolation.

/cc @atmos
