### PR TITLE
Add DjangoPackages Service.

### DIFF
--- a/docs/djangopackages
+++ b/docs/djangopackages
@@ -1,0 +1,1 @@
+Automatically update commit history as tracked on djangopackages.com.

--- a/lib/services/djangopackages.rb
+++ b/lib/services/djangopackages.rb
@@ -1,0 +1,20 @@
+class Service::DjangoPackages < Service::HttpPost
+  
+  default_events :push
+
+  url "https://www.djangopackages.com/"
+  logo_url "https://s3.amazonaws.com/opencomparison/img/logo_squares.png"
+
+  maintained_by :github => 'pydanny',
+    :twitter => '@pydanny'
+
+  supported_by :email => 'pydanny@gmail.com',
+    :twitter => '@pydanny'
+
+  # ssl_version 2
+
+  def receive_push
+    url = "https://www.djangopackages.com:443/packages/github-webhook/"
+    http_post url, :payload => generate_json(payload)
+  end
+end

--- a/test/djangopackages_test.rb
+++ b/test/djangopackages_test.rb
@@ -1,0 +1,25 @@
+require File.expand_path('../helper', __FILE__)
+
+class DjangoPackagesTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    @stubs.post "/packages/github-webhook/" do |env|
+      assert_equal 'djangopackages.com', env[:url].host
+      data = Faraday::Utils.parse_query(env[:body])
+      assert_equal 1, JSON.parse(data['payload'])['a']
+      assert_equal 1, 2
+      [200, {}, '']
+    end
+
+    svc = service({"zen" => "test", "hook_id" => "123" }, :a => 1)
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::DjangoPackages, *args
+  end
+end
+


### PR DESCRIPTION
This service updates DjangoPackages.com with the commit history of a Django package repo.

DjangoPackages.com is the community index for open-source Django packages.
