### PR TITLE
Adds Snap-CI to Github services.

### DIFF
--- a/docs/snapci
+++ b/docs/snapci
@@ -1,0 +1,11 @@
+[Snap-CI](https://snap-ci.com) will add these hooks automatically to projects which you test using Snap-CI.
+
+
+Install Notes
+-------------
+
+1.  Sign up at https://snap-ci.com with your github account
+2.  Add your repository
+3.  You're ready!
+
+For more details about Snap-CI, go to http://docs.snap-ci.com.

--- a/lib/services/snapci.rb
+++ b/lib/services/snapci.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../web', __FILE__)
+
+class Service::Snapci < Service::Web
+  self.title = "Snap CI"
+  url "https://snap-ci.com"
+  logo_url "https://snap-ci.com/assets/favicons/snap.ico"
+
+  supported_by :web => 'https://snap-ci.com/contact-us', :email => 'snap-ci@thoughtworks.com'
+  maintained_by :github => 'snap-ci'
+  default_events :push, :member
+end


### PR DESCRIPTION
[Snap-CI](https://snap-ci.com) is a Continuous Integration service.
