### PR TITLE
updated service hook so it is in sync with recent docker changes. 

### DIFF
--- a/lib/services/docker.rb
+++ b/lib/services/docker.rb
@@ -1,9 +1,7 @@
 class Service::Docker < Service::HttpPost
 
-  url "http://www.Docker.io"
-
-  # we don't have an offical logo yet, we will update when we get one.
-  # logo_url "http://www.docker.io/"
+  url "http://www.docker.com"
+  logo_url "http://www.docker.com/static/img/nav/docker-logo-loggedout.png"
 
   # kencochrane on GitHub/twitter is pinged for any bugs with the Hook code.
   maintained_by :github => 'kencochrane',
@@ -12,10 +10,10 @@ class Service::Docker < Service::HttpPost
   # Support channels for user-level Hook problems (service failure,
   # misconfigured
   supported_by :github => 'kencochrane',
-    :twitter => '@getdocker'
+    :twitter => '@docker'
 
   def receive_event
-    deliver "https://index.docker.io/hooks/github"
+    deliver "https://registry.hub.docker.com/hooks/github"
   end
 end
 

--- a/test/docker_test.rb
+++ b/test/docker_test.rb
@@ -12,7 +12,7 @@ class DockerTest < Service::TestCase
     @stubs.post "/hooks/github" do |env|
       body = JSON.parse(env[:body])
 
-      assert_equal env[:url].host, "index.docker.io"
+      assert_equal env[:url].host, "registry.hub.docker.com"
       assert_equal 'test', body['payload']['commits'][0]['id']
       assert_match 'guid-', body['guid']
       assert_equal data, body['config']


### PR DESCRIPTION
We have recently made some changes to the docker hosted services, and these changes bring the service hook back into sync.
- Changed the url from `index.docker.io` to `registry.hub.docker.com`
- Changed twitter handle from `getdocker` to `docker`
- Changed URL to `www.docker.com` from `www.docker.io`
- added a docker logo
