### PR TITLE
Classify API token as password

### DIFF
--- a/lib/services/pivotal_tracker.rb
+++ b/lib/services/pivotal_tracker.rb
@@ -1,5 +1,6 @@
 class Service::PivotalTracker < Service
-  string :token, :branch, :endpoint
+  password :token
+  string :branch, :endpoint
   white_list :endpoint, :branch
 
   def receive_push


### PR DESCRIPTION
While API token could grant access on the same level as username/password we should classify it like password. So it will be hidden in the form.
