### PR TITLE
Provide email.rb an option for Log Message to go before Changed Paths.

### DIFF
--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -13,6 +13,7 @@ class Service::Email < Service
   string     :address
   password   :secret
   boolean    :send_from_author
+  boolean    :log_message_first
   white_list :address
 
   def receive_push
@@ -112,6 +113,10 @@ class Service::Email < Service
 
   def send_from_author?
     data['send_from_author']
+  end
+
+  def log_message_first?
+    data['log_message_first']
   end
 
   def smtp_address
@@ -228,6 +233,18 @@ class Service::Email < Service
 
       EOH
 
+      log_message = align(<<-EOH)
+        Log Message:
+        -----------
+        #{commit['message']}
+
+
+      EOH
+
+      if log_message_first?
+        text << log_message
+      end
+
       if changed_paths.size > 0
         text << align(<<-EOH)
           Changed paths:
@@ -236,13 +253,9 @@ class Service::Email < Service
         EOH
       end
 
-      text << align(<<-EOH)
-        Log Message:
-        -----------
-        #{commit['message']}
-
-
-      EOH
+      if !log_message_first?
+        text << log_message
+      end
 
       text
     end

--- a/test/email_test.rb
+++ b/test/email_test.rb
@@ -67,6 +67,33 @@ class EmailTest < Service::TestCase
     assert_nil svc.messages.shift
   end
 
+  def test_log_message_last
+    # Original behavior
+    svc = service( 
+      {'address' => 'a'},
+      payload)
+
+    svc.receive_push
+
+    msg, from, to = svc.messages.shift
+    
+    assert msg.index("Changed paths:") < msg.index("Log Message:")
+  end
+
+  def test_log_message_first
+    # New optional behavior
+    svc = service( 
+      {'address' => 'a', 'log_message_first' => '1'},
+      payload)
+
+    svc.receive_push
+
+    msg, from, to = svc.messages.shift
+
+    assert msg.index("Changed paths:") > msg.index("Log Message:")
+  end
+
+    
   def service(*args)
     svc = super Service::Email, *args
     def svc.messages


### PR DESCRIPTION
This provides the Email service the option for 'Log message' to precede 'Changed paths'.  The aim is to add a new option 'Log message first' on the page Settings > Webhooks & Services > Services > Email.  

One query - I am not sure what boolean value will returned for existing users  of the Email service who have not configured this.  I have assumed it will be 'false'.   Could someone confirm that?

cheers -Ben