### PR TITLE
Added support for blank device iden

### DIFF
--- a/docs/pushbullet
+++ b/docs/pushbullet
@@ -11,6 +11,8 @@ Install Notes
 
 3. Add your api key in the field above.
 
+If you want to send to a specific device, else leave the "Device iden" field blank:
+
 4. Open [Pushbullet API](https://api.pushbullet.com/api/devices) and paste your api key to the username field, leave password empty.
 
 5. Find your desired device from the output and copy it's iden to the field above.

--- a/lib/services/pushbullet.rb
+++ b/lib/services/pushbullet.rb
@@ -17,7 +17,7 @@ class Service::Pushbullet < Service::HttpPost
     unless required_config_value('api_key').match(/^[A-Za-z0-9]+$/)
       raise_config_error "Invalid api key."
     end
-    unless required_config_value('device_iden').match(/^[A-Za-z0-9]+$/)
+    unless required_config_value('device_iden').match(/^([A-Za-z0-9]+|)$/)
       raise_config_error "Invalid device iden."
     end
 

--- a/test/pushbullet_test.rb
+++ b/test/pushbullet_test.rb
@@ -15,6 +15,12 @@ class PushbulletTest < Service::TestCase
     service(:push, @options, payload).receive_event
   end
 
+  def test_push_no_device_iden
+    @options["device_iden"] = ""
+    stub_request "push"
+    service(:push, @options, payload).receive_event
+  end
+
   def test_issue
     stub_request "issues"
     service(:issues, @options, issues_payload).receive_event


### PR DESCRIPTION
The pushbullet API does not require the device_iden and I prefer to not use it so updated the regex to accommodate this.

I was not able to test this, but have added a test for this. (also this is the first time I have touched ruby)
