### PR TITLE
Adds missing X-Github-Event header

### DIFF
--- a/lib/services/jenkins_github.rb
+++ b/lib/services/jenkins_github.rb
@@ -13,6 +13,7 @@ class Service::JenkinsGitHub < Service
     end
     http.ssl[:verify] = false # :(
     http.url_prefix = url
+    http.headers['X-GitHub-Event'] = "push"
     http_post url,
       :payload => generate_json(payload)
   end


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-23662, https://issues.jenkins-ci.org/browse/JENKINS-23661
A breaking change was introduced in https://github.com/jenkinsci/github-plugin/commit/bcc3bc1ca704b2be3f1475b616fa1b209986a1fd
