### PR TITLE
Added Cloud 66 Redeployment Support

### DIFF
--- a/docs/cloud66
+++ b/docs/cloud66
@@ -1,0 +1,26 @@
+[Cloud 66](https://www.cloud66.com) will add these hooks automatically to projects which you deploy using Cloud 66.
+This integration triggers a deployment every time you push your code into your Github repository.
+To sign up, go to https://www.cloud66.com, sign in, and start deploying!
+
+Installation Notes
+------------------
+
+To trigger a deployment after each git push:
+
+1. Click on Stack Information under your Stack details page.
+2. Here you can find the **Redeployment Key** for your stack. Copy and paste it below.
+3. You're done!
+
+Note: Only pushes into the same git branch as your stack will trigger the deployment.
+
+Getting Started with Cloud 66
+-----------------------------
+
+Cloud 66 is the easiest way to build, deploy and manage your apps on your own server on any cloud.
+
+Here is how to get started:
+
+1.  Sign up at https://www.cloud66.com with your email or github credentials
+2.  Follow the [Getting Started] section to deploy your first stack with Cloud 66.
+
+For more details about Cloud 66 go to https://www.cloud66.com

--- a/lib/services/cloud66.rb
+++ b/lib/services/cloud66.rb
@@ -1,0 +1,28 @@
+class Service::Cloud66 < Service::HttpPost
+  string :redeployment_key
+
+  default_events :push
+
+  url "https://www.cloud66.com"
+  logo_url "http://cdn.cloud66.com/images/cloud66_logo_140.png"
+
+  maintained_by :github => 'cloud66'
+
+  supported_by :web => 'https://www.cloud66.com',
+    :email => 'support@cloud66.com',
+    :twitter => '@cloud66'
+
+  def receive_event
+    redeployment_key = required_config_value('redeployment_key')
+
+		redeployment_key = redeployment_key.gsub(/\s+/, "")
+
+		if redeployment_key.size != 64
+			raise_config_error "Invalid stack redeployment key"
+		end
+
+    url = "https://hooks.cloud66.com/stacks/redeploy/#{redeployment_key[0,32]}/#{redeployment_key[32,32]}"
+
+    deliver url
+  end
+end


### PR DESCRIPTION
Cloud 66 is a application deployment service across different cloud providers. It builds, provisions and manages your app for you on any cloud. You can think of it like Heroku on your own servers.

This service integration allows simple post-commit deployment with Github as part of a Continuous Deployment solution.
