### PR TITLE
Update to support status based deployments

### DIFF
--- a/docs/autodeploy
+++ b/docs/autodeploy
@@ -6,6 +6,9 @@ Install Notes
 -------------
 
 1. `github_token` A [personal access token](https://github.com/settings/applications) from GitHub with `repo:deployment` scope.
-2. `environments` A commit delimited set of environment names to auto-deploy. e.g. production,staging.
+2. `environments` A comma delimited set of environment names to auto-deploy. e.g. production,staging.
+3. `deploy_on_status`: If checked deployments will only be created when successful [commit statuses][2] are created by your continuous integration system.
+4. `contexts` A comma delimited set of status contexts that should be verified.**Unused** e.g. ci/travis-ci, ci/circle-ci.
 
 [1]: https://developer.github.com/v3/repos/deployments
+[2]: https://developer.github.com/v3/repos/statuses


### PR DESCRIPTION
Right now this is subscribed to status and push events but only has code paths for handling push events. This does a few things.
- Creates deployments if status is checked and the incoming status is green.
- Removes the "deploy on push" button since that's implied.
- Update docs.

I started adding support for `contexts` here too, which will serve as a way to specify which ci contexts are required to create deployments(multiple-contexts).
