### PR TITLE
updated hipchat service to have quiet comments and labels

### DIFF
--- a/docs/hipchat
+++ b/docs/hipchat
@@ -1,4 +1,4 @@
-Note: HipChat has a new and improved integration with GitHub. While this 
+Note: HipChat has a new and improved integration with GitHub. While this
 service will continue to work, you really should check out the new integration.
 Read more here: http://help.hipchat.com/knowledgebase/articles/64389-github-integration
 
@@ -21,5 +21,7 @@ Options
 2. **Quiet Fork** - Suppress the room notice if a project has been forked.
 3. **Quiet Watch** - Suppress the room notice that someone has started to watch the project.
 4. **Quiet Comments** - Suppress the room notice if a comment has been made on repo.
-5. **Quiet Wiki** - Suppress the room notice if a wiki item has been updated.
-6. **Active** - Turn On or Off the service hook.
+5. **Quiet Labels** - Suppress the room notice if an issue has had any label changes.
+6. **Quiet Assigning** - Suppress the room notice if an issue has been assigned or unassigned.
+7. **Quiet Wiki** - Suppress the room notice if a wiki item has been updated.
+8. **Active** - Turn On or Off the service hook.

--- a/lib/services/hipchat.rb
+++ b/lib/services/hipchat.rb
@@ -1,12 +1,12 @@
 class Service::HipChat < Service
   password :auth_token
   string :room, :restrict_to_branch, :color, :server
-  boolean :notify, :quiet_fork, :quiet_watch, :quiet_comments, :quiet_wiki
+  boolean :notify, :quiet_fork, :quiet_watch, :quiet_comments, :quiet_labels, :quiet_assigning, :quiet_wiki
   white_list :room, :restrict_to_branch, :color
 
   default_events :commit_comment, :download, :fork, :fork_apply, :gollum,
     :issues, :issue_comment, :member, :public, :pull_request, :pull_request_review_comment,
-    :push, :watch
+    :push, :watch, :issue_label, :issue_unlabel, :issue_assign, :issue_unassign
 
   def receive_event
     # make sure we have what we need
@@ -31,6 +31,8 @@ class Service::HipChat < Service
     return if event.to_s =~ /watch/ && data['quiet_watch']
     return if event.to_s =~ /comment/ && data['quiet_comments']
     return if event.to_s =~ /gollum/ && data['quiet_wiki']
+    return if event.to_s =~ /label/ && data['quiet_labels']
+    return if event.to_s =~ /assign/ && data['quiet_assigning']
 
     http.headers['X-GitHub-Event'] = event.to_s
 

--- a/lib/services/hipchat.rb
+++ b/lib/services/hipchat.rb
@@ -31,8 +31,8 @@ class Service::HipChat < Service
     return if event.to_s =~ /watch/ && data['quiet_watch']
     return if event.to_s =~ /comment/ && data['quiet_comments']
     return if event.to_s =~ /gollum/ && data['quiet_wiki']
-    return if payload['action'].to_s =~ /label/ && data['quiet_labels']
-    return if payload['action'].to_s =~ /assign/ && data['quiet_assigning']
+    return if event.to_s =~ /issue|pull_request/ && payload['action'].to_s =~ /label/ && data['quiet_labels']
+    return if event.to_s =~ /issue|pull_request/ && payload['action'].to_s =~ /assign/ && data['quiet_assigning']
 
     http.headers['X-GitHub-Event'] = event.to_s
 

--- a/lib/services/hipchat.rb
+++ b/lib/services/hipchat.rb
@@ -6,7 +6,7 @@ class Service::HipChat < Service
 
   default_events :commit_comment, :download, :fork, :fork_apply, :gollum,
     :issues, :issue_comment, :member, :public, :pull_request, :pull_request_review_comment,
-    :push, :watch, :issue_label, :issue_unlabel, :issue_assign, :issue_unassign
+    :push, :watch
 
   def receive_event
     # make sure we have what we need
@@ -31,8 +31,8 @@ class Service::HipChat < Service
     return if event.to_s =~ /watch/ && data['quiet_watch']
     return if event.to_s =~ /comment/ && data['quiet_comments']
     return if event.to_s =~ /gollum/ && data['quiet_wiki']
-    return if event.to_s =~ /label/ && data['quiet_labels']
-    return if event.to_s =~ /assign/ && data['quiet_assigning']
+    return if payload['action'].to_s =~ /label/ && data['quiet_labels']
+    return if payload['action'].to_s =~ /assign/ && data['quiet_assigning']
 
     http.headers['X-GitHub-Event'] = event.to_s
 

--- a/test/hip_chat_test.rb
+++ b/test/hip_chat_test.rb
@@ -74,6 +74,36 @@ class HipChatTest < Service::TestCase
     @stubs.verify_stubbed_calls
   end
 
+  def test_quiet_labels_silences_comment_events
+    [:issue_labeled, :issue_unlabeled].each do |label_event|
+      svc = service(label_event,
+        default_data_plus('quiet_labels' => '1'), simple_payload )
+      assert_nothing_raised { svc.receive_event }
+    end
+  end
+
+  def test_quiet_labels_will_not_silence_other_events
+    stub_simple_post
+    svc = service(default_data_plus('quiet_labels' => '1'), simple_payload)
+    svc.receive_event
+    @stubs.verify_stubbed_calls
+  end
+
+  def test_quiet_assigned_silences_comment_events
+    [:issue_assigned, :issue_unassigned].each do |assigned_event|
+      svc = service(assigned_event,
+        default_data_plus('quiet_assigning' => '1'), simple_payload )
+      assert_nothing_raised { svc.receive_event }
+    end
+  end
+
+  def test_quiet_assigned_will_not_silence_other_events
+    stub_simple_post
+    svc = service(default_data_plus('quiet_assigning' => '1'), simple_payload)
+    svc.receive_event
+    @stubs.verify_stubbed_calls
+  end
+
   def test_quiet_wiki_silences_wiki_events
     svc = service(:gollum,
       default_data_plus('quiet_wiki' => '1'), simple_payload )

--- a/test/hip_chat_test.rb
+++ b/test/hip_chat_test.rb
@@ -75,9 +75,9 @@ class HipChatTest < Service::TestCase
   end
 
   def test_quiet_labels_silences_comment_events
-    [:issue_labeled, :issue_unlabeled].each do |label_event|
+    [:issue, :pull_request].each do |label_event|
       svc = service(label_event,
-        default_data_plus('quiet_labels' => '1'), simple_payload )
+        default_data_plus('quiet_labels' => '1'), actionable_payload('labeled') )
       assert_nothing_raised { svc.receive_event }
     end
   end
@@ -90,9 +90,9 @@ class HipChatTest < Service::TestCase
   end
 
   def test_quiet_assigned_silences_comment_events
-    [:issue_assigned, :issue_unassigned].each do |assigned_event|
+    [:issue, :pull_request].each do |assigned_event|
       svc = service(assigned_event,
-        default_data_plus('quiet_assigning' => '1'), simple_payload )
+        default_data_plus('quiet_assigning' => '1'), actionable_payload('assigned') )
       assert_nothing_raised { svc.receive_event }
     end
   end
@@ -123,6 +123,10 @@ class HipChatTest < Service::TestCase
 
   def simple_payload
     {'a' => 1, 'ref' => 'refs/heads/master'}
+  end
+
+  def actionable_payload(action = 'labeled')
+    {'a' => 1, 'ref' => 'refs/heads/master', 'action' => action}
   end
 
   def stub_simple_post


### PR DESCRIPTION
This is a patch for issue #902 trying to make the hipchat integration a lot less verbose.
We tried moving to their new add-on but it was even more verbose...

This is my first time working with github-services so feel free to point anything out that I have missed.
I wasn't clear if I needed to do anything else to get the options appearing in the control panel on github itself apart from add them to the hipchat.rb file
