### PR TITLE
Add X-GitHub-Services-Version to the service request headers

### DIFF
--- a/lib/service.rb
+++ b/lib/service.rb
@@ -662,7 +662,7 @@ class Service
       :adapter => :net_http,
       :request => {:timeout => 10, :open_timeout => 5},
       :ssl => {:verify_depth => 5},
-      :headers => {}
+      :headers => {"X-GitHub-Services-Version" => current_sha[0..7]}
     }
   end
 


### PR DESCRIPTION
This exposes the currently running version of github/github-services as a request header. This is available for all `http` based services as well as webhooks.

/cc #906 @kdaigle @atmos
