### PR TITLE
Add workaround to Bugzilla service for Ruby XMLRPC bug

### DIFF
--- a/lib/services/bugzilla.rb
+++ b/lib/services/bugzilla.rb
@@ -62,6 +62,11 @@ class Service::Bugzilla < Service
     # XMLRPC client to communicate with Bugzilla server
     @xmlrpc_client ||= begin
       client = XMLRPC::Client.new2("#{data['server_url'].to_s}/xmlrpc.cgi")
+
+      # Workaround for XMLRPC bug - https://bugs.ruby-lang.org/issues/8182
+      # Should no longer be needed when we start running Ruby 2.2
+      client.http_header_extra = {"accept-encoding" => "identity"}
+
       result = client.call('User.login', {'login' => data['username'].to_s, 'password' => data['password'].to_s})
       @token = result['token']
       client


### PR DESCRIPTION
Workaround for a [XMLRPC bug](https://bugs.ruby-lang.org/issues/8182) which causes an exception when XMLRPC tries to verify the content-length of the response. The fix for this bug is targeted for Ruby 2.2 so we'll need to run this workaround until a fix lands.
