### PR TITLE
Fix xmpp-muc service

### DIFF
--- a/lib/services/xmpp_muc.rb
+++ b/lib/services/xmpp_muc.rb
@@ -90,9 +90,9 @@ class Service::XmppMuc < Service::HttpPost
         rescue ::Jabber::ClientAuthenticationFailure
           raise_config_error 'Authentication error'
         rescue ::Jabber::JabberError
-          raise_config_error 'XMPP Error: #{$!.to_s}'
+          raise_config_error "XMPP Error: #{$!.to_s}"
         rescue StandardError => e
-          raise_config_error 'Unknown error: #{$!.to_s}'
+          raise_config_error "Unknown error: #{$!.to_s}"
         end
       end
       @muc


### PR DESCRIPTION
I fixed 2 issues in the XMPP-MUC service:
- The incorrect password was being sent as the `room_password`
- _Unknown error_ was always being raised on success.

I tested this locally and it works. /cc @atmos @lloydwatkin 
