### PR TITLE
removed uppercase from variable name

### DIFF
--- a/docs/nhook
+++ b/docs/nhook
@@ -1,12 +1,12 @@
-Use this service to automatically trigger build and deploy of your package into NuGet when you push to GitHub.
+Use this service to automatically trigger the build and deploy of your package into NuGet when you push into GitHub.
 
-Install Notes
--------------
+Installation Notes
+------------------
 
-1. Login to https://www.nuget.org.
-2. Navigate to your account page. For now https://www.nuget.org/account
-3. Copy your API Key into GitHub service setting. This API Key will use for publishing you packages.
+1. Login to https://www.nuget.org
+2. Navigate to your account page https://www.nuget.org/account
+3. Copy your API Key into GitHub service settings. This API Key will be used for publishing your packages.
 
-For more details about nHook, go to http://www.nhook.net
+For more details about nHook go to http://www.nhook.net
 
-PS: Now it works just with public repositories.
+P.S. The service only works with public repositories for now.


### PR DESCRIPTION
When I tried using my service I had received an error 'Missing ApiKey', what is supposed to mean that something is wrong with routing of input field value to the service. I'm not sure that my changes will fix the problem, but I presume that the problem can be in case-sensitive of names, so I've removed uppercase from variables name in the pull request. But, if you have any suggestions about the problem, would you mind giving me a helping hand and explaining. Thx!
