### PR TITLE
only push irc issues messages on open/close

### DIFF
--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -30,7 +30,7 @@ class Service::IRC < Service
   end
 
   def receive_issues
-    send_messages "#{irc_issue_summary_message} #{fmt_url url}"
+    send_messages "#{irc_issue_summary_message} #{fmt_url url}" if action =~ /(open)|(close)/
   end
 
   def receive_issue_comment


### PR DESCRIPTION
Similarly to pull requests (457bab4db8bb70e72b85e7fbe140ae3ce3cde364), only open and close actions for issues should be announced.

After I managed to set the hook's types to "issues" using the API I was confronted with a lot of `... labeled issue #...` spam that nobody cares about. This PR removes that.

I don't know which actions are send overall (couldn't find actions docs, only for types), so I just restricted them to open and close like for pull requsts.
