### PR TITLE
Add Reviewable to GitHub services.

### DIFF
--- a/docs/reviewable
+++ b/docs/reviewable
@@ -1,0 +1,17 @@
+[Reviewable](https://reviewable.io) will add this hook automatically to your connected repositories.
+
+GitHub code reviews done right
+------------------------------
+- Side-by-side and unified diffs with syntax highlighting
+- Smart handling of merges, rebases, and whitespace
+- Incremental deltas since last time you looked at a file
+- Automatic commit aggregation into revisions
+- Comments carried across file changes
+- Tracking of unresolved comments and unreviewed files
+
+Install Notes
+-------------
+
+1.  Sign in at [https://reviewable.io](https://reviewable.io) with your GitHub account.
+2.  Connect your repository by clicking on it.
+3.  You're done!

--- a/lib/services/reviewable.rb
+++ b/lib/services/reviewable.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../web', __FILE__)
+
+class Service::Reviewable < Service::Web
+  self.title = 'Reviewable'
+  url 'https://reviewable.io'
+  logo_url 'https://reviewable.io/favicon-96x96.png'
+
+  supported_by :email => 'support@reviewable.io'
+  maintained_by :github => 'reviewable'
+  default_events :pull_request, :issue_comment, :pull_request_review_comment
+end

--- a/test/reviewable_test.rb
+++ b/test/reviewable_test.rb
@@ -1,0 +1,28 @@
+require File.expand_path('../helper', __FILE__)
+
+class ReviewableTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_event
+    svc = service :pull_request, {}, pull_payload
+
+    @stubs.post "/queues/github.json" do |env|
+      assert_equal 'https', env[:url].scheme
+      assert_equal 'reviewable.firebaseio.com', env[:url].host
+      assert_equal 'application/json', env[:request_headers]['content-type']
+      assert_equal pull_payload, JSON.parse(env[:body])
+      [200, {}, '']
+    end
+
+    svc.receive_event
+  end
+
+  def service(event_type, options = {}, *args)
+    default_options = {
+      'url' => 'https://reviewable.firebaseio.com/queues/github.json', 'content_type' => 'json'
+    }
+    super Service::Reviewable, event_type, default_options.merge(options), *args
+  end
+end


### PR DESCRIPTION
Note that reviewable.io is not live yet, but will be coming online soon.
