### PR TITLE
Add enterprise api url config options to OpsWorks and Heroku

### DIFF
--- a/docs/awsopsworks
+++ b/docs/awsopsworks
@@ -28,3 +28,4 @@ Install Notes
 4. **Aws Access Key Id** (required) - Access key id of an AWS IAM user having the permission for the `opsworks:CreateDeployment` action.
 5. **Aws Secret Access Key** (required) - Corresponding secret access key of the AWS IAM user.
 6. **GitHub Token** (Optional) - A GitHub personal access token with `repo_deployment` scope to post deployment statuses back via the API.
+7. **GitHub API Url** (Optional) - The URL for the GitHub API. Override this for enterprise. e.g. `https://enterprise.myorg.com`.

--- a/docs/herokubeta
+++ b/docs/herokubeta
@@ -14,3 +14,4 @@ Install Notes
 1. `name` The application name on heroku to deploy to.
 2. `heroku_token` A user or [direct authorization](https://devcenter.heroku.com/articles/oauth#direct-authorization) token from heroku.
 3. `github_token` A [personal access token](https://github.com/settings/applications) from GitHub with the `repo` scope. We generate an [archive link](https://developer.github.com/v3/repos/contents/#get-archive-link) for the heroku API with it.
+4. `github_api_url` The URL for the GitHub API. Override this for enterprise. **Optional** e.g. `https://enterprise.myorg.com`.

--- a/lib/services/heroku_beta.rb
+++ b/lib/services/heroku_beta.rb
@@ -1,11 +1,10 @@
 require 'base64'
 
 class Service::HerokuBeta < Service::HttpPost
-  string :name
-  # boolean  :basic_auto_deploy, :status_driven_auto_deploy
+  string :name, :github_api_url
   password :heroku_token, :github_token
 
-  white_list :name
+  white_list :name, :github_api_url
 
   default_events :deployment
 
@@ -86,7 +85,7 @@ class Service::HerokuBeta < Service::HttpPost
     }
 
     deployment_path = "/repos/#{github_repo_path}/deployments/#{payload['id']}/statuses"
-    response = http_post "https://api.github.com#{deployment_path}" do |req|
+    response = http_post "#{github_api_url}#{deployment_path}" do |req|
       req.headers.merge!(default_github_headers)
       req.body = JSON.dump(deployment_status_options)
     end
@@ -129,7 +128,7 @@ class Service::HerokuBeta < Service::HttpPost
   end
 
   def github_get(path)
-    http_get "https://api.github.com#{path}" do |req|
+    http_get "#{github_api_url}#{path}" do |req|
       req.headers.merge!(default_github_headers)
     end
   end
@@ -141,6 +140,14 @@ class Service::HerokuBeta < Service::HttpPost
       'Content-Type'  => "application/json",
       'Authorization' => "token #{required_config_value('github_token')}"
     }
+  end
+
+  def github_api_url
+    if config_value("github_api_url").empty?
+      "https://api.github.com"
+    else
+      config_value("github_api_url")
+    end
   end
 
   def raise_config_error_with_message(sym)


### PR DESCRIPTION
This allows for configuration options for opsworks and heroku on enterprise.
