### PR TITLE
Use named refs until the deployments API supports shas and refs

### DIFF
--- a/lib/services/auto_deploy.rb
+++ b/lib/services/auto_deploy.rb
@@ -102,7 +102,7 @@ class Service::AutoDeploy < Service::HttpPost
 
     environment_names.each do |environment_name|
       deployment_options = {
-        "ref"               => sha,
+        "ref"               => default_branch,
         "payload"           => last_deployment_payload_for(environment_name),
         "environment"       => environment_name,
         "description"       => push_deployment_description,
@@ -121,7 +121,7 @@ class Service::AutoDeploy < Service::HttpPost
     if status_payload_contains_default_branch?
       environment_names.each do |environment_name|
         deployment_options = {
-          "ref"               => sha,
+          "ref"               => default_branch,
           "payload"           => last_deployment_payload_for(environment_name),
           "environment"       => environment_name,
           "description"       => status_deployment_description,

--- a/test/auto_deploy_test.rb
+++ b/test/auto_deploy_test.rb
@@ -37,7 +37,7 @@ class AutoDeployTest < Service::TestCase
     services_sha = Service.current_sha[0..7]
 
     github_post_body = {
-      "ref"               => "a47fd41f",
+      "ref"               => "master",
       "payload"           => {"hi"=>"haters"},
       "environment"       => "production",
       "description"       => "Auto-Deployed on push by GitHub Services@#{services_sha} for rtomayko - master@a47fd41f",
@@ -70,7 +70,7 @@ class AutoDeployTest < Service::TestCase
     services_sha = Service.current_sha[0..7]
 
     github_post_body = {
-      "ref"               => "7b80eb10",
+      "ref"               => "master",
       "payload"           => {"hi"=>"haters"},
       "environment"       => "production",
       "description"       => "Auto-Deployed on status by GitHub Services@#{services_sha} for rtomayko - master@7b80eb10",
@@ -93,7 +93,7 @@ class AutoDeployTest < Service::TestCase
     services_sha = Service.current_sha[0..7]
 
     github_post_body = {
-      "ref"               => "7b80eb10",
+      "ref"               => "master",
       "payload"           => {"hi"=>"haters"},
       "environment"       => "production",
       "description"       => "Auto-Deployed on status by GitHub Services@#{services_sha} for rtomayko - master@7b80eb10",


### PR DESCRIPTION
Right now the auto-deploy feature uses the sha that was pushed instead of the ref. This can be problematic with certain integrations that don't support deploying specific shas. We're planning to enhance the deployments API to support `ref@sha` syntax in the next few weeks but I'd like to support refs until we do.
