### PR TITLE
Remove `ssl_version` option from webhook

### DIFF
--- a/lib/services/web.rb
+++ b/lib/services/web.rb
@@ -4,26 +4,19 @@ class Service::Web < Service
   string :url,
     # old hooks send form params ?payload=JSON(...)
     # new hooks should set content_type == 'json'
-    :content_type,
-
-    # 2 or 3
-    :ssl_version
+    :content_type
 
   # adds a X-Hub-Signature of the body content
   # X-Hub-Signature: sha1=....
   password :secret
 
-  white_list :url, :content_type, :ssl_version
+  white_list :url, :content_type
 
   boolean :insecure_ssl # :(
 
   def receive_event
     http.headers['X-GitHub-Event'] = event.to_s
     http.headers['X-GitHub-Delivery'] = delivery_guid.to_s
-
-    if data['ssl_version'].to_i == 3
-      http.ssl[:version] = :sslv3
-    end
 
     res = deliver data['url'], :content_type => data['content_type'],
       :insecure_ssl => data['insecure_ssl'].to_i == 1, :secret => data['secret']


### PR DESCRIPTION
Due to the SSLv3 POODLE issue, anyone who has SSLv3 set manually on their webhook won't be able to communicate with servers who (likely) dropped support for SSLv3. This also impacts anyone who uses something like Heroku to host their integration. Given SSLv3 is insecure regardless, I think it's best to completely remove this option.

The documentation also stated that you could set to SSLv2 but that isn't actually true in the code below. This clarifies and relies on TLS.

cc @jdpace @dbussink
