### PR TITLE
Add foxytask service

### DIFF
--- a/docs/foxytask
+++ b/docs/foxytask
@@ -1,0 +1,23 @@
+Foxytask allow to manage your GitHub issues.
+You can :
+ - order issues
+ - change issue milestone by drag & drop
+ - estimate issues
+ - add milestone capacity
+ - have an overview of your project advancement
+
+This service hook will inform Foxytask every time you create or modify an issue in GitHub.
+
+Install Notes
+-------------
+
+Foxytask will install this hook automatically on sign up. However, if creating the service didn't succeed or you accidentally deleted it, you can also install it manually.
+
+1.  Sign in at https://www.foxytask.com/ (you can sign in with GitHub)
+2.  If the service wasn't set: Go to your project's settings and copy the project uuid.
+3.  Paste the  project uuid into the text field above.
+4.  Make sure the "Active" checkbox is ticked, and click "Update Settings".
+5.  Click on the "Foxytask" service name and then click the "Test Hook" link.
+6.  Now there's a running build on your Foxytask dashboard.
+
+Check out more details on Foxytask at https://www.foxytask.com 

--- a/lib/services/foxytask.rb
+++ b/lib/services/foxytask.rb
@@ -1,0 +1,21 @@
+class Service::Foxytask < Service::HttpPost
+  url "http://www.foxytask.com"
+  logo_url "http://www.foxytask.com/img/FoxNegatif.png"
+
+  default_events :issues, :issue_comment, :public
+
+  maintained_by github: 'akta3d'
+  supported_by  web: 'http://www.foxytask.com',
+                email: 'support@intia.fr'
+
+  def receive_event
+	http.headers['content-type'] = 'application/json'
+    http_post foxytask_url, payload: generate_json(payload)
+  end
+  
+  private
+
+  def foxytask_url
+    "http://www.foxytask.com/webhook"
+  end
+end

--- a/test/foxytask_test.rb
+++ b/test/foxytask_test.rb
@@ -1,0 +1,35 @@
+require File.expand_path('../helper', __FILE__)
+
+class FoxytaskTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_issues
+    @stubs.post "/webhook" do |env|
+      assert_equal 'www.foxytask.com', env[:url].host
+      assert_equal 'application/json',
+        env[:request_headers]['content-type']
+      [200, {}, '']
+    end
+
+    svc = service :push, payload
+    svc.receive_issues
+  end
+
+  def test_issue_comment
+    @stubs.post "/webhook" do |env|
+      assert_equal 'www.foxytask.com', env[:url].host
+      assert_equal 'application/json',
+        env[:request_headers]['content-type']
+      [200, {}, '']
+    end
+
+    svc = service :push, payload
+    svc.receive_issue_comment
+  end
+
+  def service(*args)
+    super Service::Foxytask, *args
+  end
+end


### PR DESCRIPTION
Foxytask is a simple application help you to manage project on github.
You can organize issues in milestones, add a capacity on milestone and attribute an estimate time on issues
