### PR TITLE
Fix "send_from_author" email setting when setting is set to 0

### DIFF
--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -111,7 +111,7 @@ class Service::Email < Service
   end
 
   def send_from_author?
-    data['send_from_author']
+    data['send_from_author'].to_i == 1
   end
 
   def smtp_address

--- a/test/email_test.rb
+++ b/test/email_test.rb
@@ -67,6 +67,35 @@ class EmailTest < Service::TestCase
     assert_nil svc.messages.shift
   end
 
+  def test_push_from_do_not_reply
+    svc = service(
+      {'address' => 'a', 'send_from_author' => '0'},
+      payload)
+
+    svc.receive_push
+
+    msg, from, to = svc.messages.shift
+    assert_match 'noreply@github.com', from
+    assert_equal 'a', to
+
+    assert_nil svc.messages.shift
+  end
+
+
+  def test_push_from_do_not_reply_with_no_option_set
+    svc = service(
+      {'address' => 'a'},
+      payload)
+
+    svc.receive_push
+
+    msg, from, to = svc.messages.shift
+    assert_match 'noreply@github.com', from
+    assert_equal 'a', to
+
+    assert_nil svc.messages.shift
+  end
+
   def service(*args)
     svc = super Service::Email, *args
     def svc.messages


### PR DESCRIPTION
When the email author setting is set to `0`, the `send_as_author` setting doesn't take affect. This will allow the setting to be `0` and still work correctly.

cc @izuzak 
