### PR TITLE
TeamCity service: add option to send full branch reference on push event

### DIFF
--- a/docs/teamcity
+++ b/docs/teamcity
@@ -1,30 +1,30 @@
-TeamCity is a continuous integration server that automates the building and
-testing of your software.  The GitHub TeamCity service can be used to trigger
-builds after code has been pushed to your git repository.
+[TeamCity](https://www.jetbrains.com/teamcity/) is a continuous integration server that automates the building and testing of your software.
+The GitHub TeamCity service can be used to trigger builds after code has been pushed to your git repository.
 
 Install Notes
 -------------
 
 1. Your TeamCity server must be accessible from the internet.
 
-2. "base_url" is the URL to your TeamCity server
+2. "Base url" is the URL to your TeamCity server
    Example: https://teamcity.example.com/ or http://teamcity.example.com/teamcity/
 
-3. "build_type_id" is the identifier of the build configuration you want to
-   trigger. Multiple configurations can be triggered by specifying a
-   comma-separated list of identifiers.
+3. "Build type" is the identifier of the build configuration you want to trigger.
+   Multiple configurations can be triggered by specifying a comma-separated list of identifiers.
    Example: "bt123", which can be found in URL of the build configuration page
    ("...viewType.html?buildTypeId=bt123&...")
 
-4. "username" and "password" - username and password of a TeamCity user that can
-   trigger a manual build of the TeamCity build configuration defined in
-   "build_type_id"
+4. "Username" and "Password" - username and password of a TeamCity user that can
+   trigger a manual build of the TeamCity build configuration defined in "Build type"
 
-5. "branches" is an optional space-separated list of branches to watch commits
-   for.  Commits to other branches will be ignored. If no branches are
-   specified, TeamCity will be notified of all commits.
+5. "Branches" (Optional) is an space-separated list of branches to watch commits for.
+   Commits to other branches will be ignored.
+   If no branches are specified, TeamCity will be notified of all commits.
 
-6. Since TeamCity uses BASIC authentication, it is highly recommended that the
+6. "Full branch ref" if enabled full branch reference (e.g. 'refs/heads/master')
+   will be send to TeamCity server. Otherwise 'refs/heads' will be omitted.
+
+7. Since TeamCity uses BASIC authentication, it is highly recommended that the
    TeamCity server use HTTPS/SSL to protect the password that is passed
    unencrypted over the internet.
 

--- a/lib/services/teamcity.rb
+++ b/lib/services/teamcity.rb
@@ -1,14 +1,21 @@
 class Service::TeamCity < Service
-  string   :base_url, :build_type_id, :branches, :username
+  string :base_url, :build_type_id, :branches
+  boolean :full_branch_ref
+  string :username
   password :password
-  white_list :base_url, :build_type_id, :branches, :username
+  white_list :base_url, :build_type_id, :branches, :username, :full_branch_ref
+
+  maintained_by :github => 'JetBrains'
+
+  supported_by :web => 'http://confluence.jetbrains.com/display/TW/Feedback',
+               :email => 'teamcity-support@jetbrains.com'
 
   def receive_push
     return if payload['deleted']
 
     branches = data['branches'].to_s.split(/\s+/)
     ref = payload["ref"].to_s
-    branch = ref.split("/", 3).last
+    branch = data['full_branch_ref'] ? ref : ref.split("/", 3).last
     return unless branches.empty? || branches.include?(branch)
 
     # :(

--- a/test/teamcity_test.rb
+++ b/test/teamcity_test.rb
@@ -71,6 +71,23 @@ class TeamCityTest < Service::TestCase
     svc.receive_push
   end
 
+  def test_push_with_branch_full_ref
+    url = "/abc/httpAuth/action.html"
+    @stubs.get url do |env|
+      assert_equal 'refs/heads/branch/name', env[:params]['branchName']
+      [200, {}, '']
+    end
+
+    svc = service({
+      'base_url' => 'http://teamcity.com/abc',
+      'build_type_id' => 'btid',
+      'full_branch_ref' => true
+    }, {
+      'ref' => 'refs/heads/branch/name'
+    })
+    svc.receive_push
+  end
+
   def service(*args)
     super Service::TeamCity, *args
   end


### PR DESCRIPTION
This pull-request addresses issue when TeamCity server expecting full branch reference instead of short one.
Added maintainer/support information.
Documentation changes.
