### PR TITLE
Checks for boolean values of nil or 0

### DIFF
--- a/lib/services/commandoio.rb
+++ b/lib/services/commandoio.rb
@@ -52,7 +52,7 @@ class Service::Commandoio < Service::HttpPost
 
     params.merge!(:server          => data['server'])             if data['server']
     params.merge!(:groups          => groups)                     unless groups.nil?
-    params.merge!(:halt_on_stderr  => data['halt_on_stderr'])     if data['halt_on_stderr']
+    params.merge!(:halt_on_stderr  => data['halt_on_stderr'])     unless data['halt_on_stderr'].nil? || data['halt_on_stderr'] == 0
     params.merge!(:notes           => CGI.escape(data['notes']))  if data['notes']
 
     http_post url, params


### PR DESCRIPTION
This change is related to #971 

It only adds the _halt_on_stderr_ param if the value isn't `nil` or `0`.
