### PR TITLE
Fix typo in IRC service documentation

### DIFF
--- a/docs/irc
+++ b/docs/irc
@@ -78,7 +78,7 @@ _Recommended_, as it decreases channel noise.  Requires the IRC channel to allow
 > On freenode, allow external messages to the channel by messaging [ChanServ](https://freenode.net/services.shtml):
 >
 > ```
-> /msg ChanServ set #CHANNELNAME mlock -n`
+> /msg ChanServ set #CHANNELNAME mlock -n
 > ```
 >
 > On most other IRC networks, set the channel mode directly:


### PR DESCRIPTION
Sorry, I missed a typo in [PR#963](https://github.com/github/github-services/pull/963).

cc @kdaigle 
