### PR TITLE
The default behaviour of 'Always running a build' (with the add2Queue pa...

### DIFF
--- a/test/teamcity_test.rb
+++ b/test/teamcity_test.rb
@@ -88,6 +88,24 @@ class TeamCityTest < Service::TestCase
     svc.receive_push
   end
 
+  def test_push_when_check_for_changes_is_true
+    url = "/abc/httpAuth/action.html"
+    @stubs.get url do |env|
+      assert_equal 'teamcity.com', env[:url].host
+      assert_equal 'btid', env[:params]['checkForChangesBuildType']
+      [200, {}, '']
+    end
+
+    svc = service({
+                      'base_url' => 'http://teamcity.com/abc',
+                      'build_type_id' => 'btid',
+                      'check_for_changes_only' => true
+                  }, 'payload')
+    svc.receive_push
+  end
+
+
+
   def service(*args)
     super Service::TeamCity, *args
   end


### PR DESCRIPTION
...rameter) is not always desirable, because some TeamCity setups can have carefully configured rules about when to actually do a build which are ignored by this direct approach. This commit adds the option to just poke the TeamCity instance to check for changes (effectively the same as hitting the 'Check for pending changes' option in the TeamCity web user interface), which allows any TC build-rules to be applied.

The checkForChangesBuildType parameter is not well documented, but it is directly referenced by a JetBrains employee Yegor Yarko here:

http://youtrack.jetbrains.com/issue/TW-4134#comment=27-9255
