### PR TITLE
Update deployment services to new payloads

### DIFF
--- a/lib/service/events/deployment_helpers.rb
+++ b/lib/service/events/deployment_helpers.rb
@@ -1,17 +1,20 @@
 module Service::DeploymentHelpers
   def self.sample_deployment_payload
     {
-      "id"=>721,
-      "ref"=>"master",
-      "sha"=>"9be5c2b9c34c1f8beb0cec30bb0c875d098f45ef",
-      "name"=>"atmos/my-robot",
-      "environment"=>"production",
-      "payload"=>{
-        "config"=>{
-          "heroku_production_name"=>"my-app"
-        }
+      "deployment" => {
+        "id"=>721,
+        "ref"=>"master",
+        "sha"=>"9be5c2b9c34c1f8beb0cec30bb0c875d098f45ef",
+        "name"=>"atmos/my-robot",
+        "task"=>"deploy",
+        "environment"=>"production",
+        "payload"=>{
+          "config"=>{
+            "heroku_production_name"=>"my-app"
+          }
+        },
+        "description"=>nil,
       },
-      "description"=>nil,
       "repository"=>
       {
         "id"=>16650088,

--- a/lib/services/aws_code_deploy.rb
+++ b/lib/services/aws_code_deploy.rb
@@ -18,7 +18,7 @@ class Service::AwsCodeDeploy < Service::HttpPost
   url "http://docs.aws.amazon.com/codedeploy/latest/APIReference/"
 
   def environment
-    payload['environment']
+    payload['deployment']['environment']
   end
 
   def application_name
@@ -36,9 +36,9 @@ class Service::AwsCodeDeploy < Service::HttpPost
   end
 
   def codedeploy_payload
-    payload['payload'] &&
-      payload['payload']['config'] &&
-      payload['payload']['config']['codedeploy']
+    payload['deployment']['payload'] &&
+      payload['deployment']['payload']['config'] &&
+      payload['deployment']['payload']['config']['codedeploy']
   end
 
   def receive_event
@@ -58,7 +58,7 @@ class Service::AwsCodeDeploy < Service::HttpPost
     options = {
       :revision => {
         :git_hub_location => {
-          :commit_id  => payload["sha"],
+          :commit_id  => payload['deployment']["sha"],
           :repository => github_repo_path,
         },
         :revision_type => "GitHub"
@@ -78,10 +78,10 @@ class Service::AwsCodeDeploy < Service::HttpPost
     deployment_status_options = {
       "state"       => "success",
       "target_url"  => aws_code_deploy_client_url,
-      "description" => "Deployment #{payload['id']} Accepted by Amazon. (github-services@#{Service.current_sha[0..7]})"
+      "description" => "Deployment #{payload['deployment']['id']} Accepted by Amazon. (github-services@#{Service.current_sha[0..7]})"
     }
 
-    deployment_path = "/repos/#{github_repo_path}/deployments/#{payload['id']}/statuses"
+    deployment_path = "/repos/#{github_repo_path}/deployments/#{payload['deployment']['id']}/statuses"
     response = http_post "#{github_api_url}#{deployment_path}" do |req|
       req.headers.merge!(default_github_headers)
       req.body = JSON.dump(deployment_status_options)

--- a/lib/services/heroku_beta.rb
+++ b/lib/services/heroku_beta.rb
@@ -22,15 +22,15 @@ class Service::HerokuBeta < Service::HttpPost
   end
 
   def environment
-    payload['environment']
+    payload['deployment']['environment']
   end
 
   def ref
-    payload['ref']
+    payload['deployment']['ref']
   end
 
   def sha
-    payload['sha'][0..7]
+    payload['deployment']['sha'][0..7]
   end
 
   def version_string
@@ -84,7 +84,7 @@ class Service::HerokuBeta < Service::HttpPost
       "description" => "Created by GitHub Services@#{Service.current_sha[0..7]}"
     }
 
-    deployment_path = "/repos/#{github_repo_path}/deployments/#{payload['id']}/statuses"
+    deployment_path = "/repos/#{github_repo_path}/deployments/#{payload['deployment']['id']}/statuses"
     response = http_post "#{github_api_url}#{deployment_path}" do |req|
       req.headers.merge!(default_github_headers)
       req.body = JSON.dump(deployment_status_options)


### PR DESCRIPTION
This brings deployment related integrations up to date with the formatting outlined on the [developer blog](https://developer.github.com/changes/2014-10-21-deployment-webhook-payload-changes/).
