### PR TITLE
Update minimum aws-sdk-core to support Lambda service

### DIFF
--- a/github-services.gemspec
+++ b/github-services.gemspec
@@ -61,8 +61,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk", "~> 1.27"
   spec.add_dependency "httparty", "0.7.4"
 
-  # AWS CodeDeploy
-  spec.add_dependency "aws-sdk-core", "~>2.0.8"
+  # AWS CodeDeploy, Lambda
+  spec.add_dependency "aws-sdk-core", "~>2.0.11"
 
   spec.files = %w(Gemfile LICENSE README.mkdn CONTRIBUTING.md Rakefile)
   spec.files << "#{lib}.gemspec"


### PR DESCRIPTION
Lambda notification hook in-progress
