### PR TITLE
Add issue tracking to the Kanbanize service.

### DIFF
--- a/docs/kanbanize
+++ b/docs/kanbanize
@@ -5,3 +5,5 @@ Install Notes
 2. **Kanbanize api key** - A special API key provided by Kanbanize
 3. **Branch Filter** - A Comma-separated list of branches which will be automatically inspected. Leave blank to include all branches.
 4. **Restrict to Last Commit** - Only the last commit of each push will be inspected for task IDs.
+5. **Track Project Issues In Kanbanize** - Open/Move to Done a card when a project issue is Open/Closed
+6. **Project Issues Board Id** - The ID of the board that must keep the project issue cards. You can see the board ID on the Kanbanize dashboard screen, next to the board name.

--- a/lib/services/kanbanize.rb
+++ b/lib/services/kanbanize.rb
@@ -3,9 +3,13 @@ class Service::Kanbanize < Service
   string :kanbanize_api_key
   string :restrict_to_branch
   boolean :restrict_to_last_commit
+  boolean :track_project_issues_in_kanbanize
+  string :project_issues_board_id
 
   # Skip the api key from the debug logs.
-  white_list :kanbanize_domain_name, :restrict_to_branch, :restrict_to_last_comment
+  white_list :kanbanize_domain_name, :restrict_to_branch, :restrict_to_last_comment, :track_project_issues_in_kanbanize, :project_issues_board_id
+
+  default_events :push, :issues, :issue_comment
 
   url "https://kanbanize.com/"
   logo_url "https://kanbanize.com/application/resources/images/logo.png"
@@ -13,26 +17,30 @@ class Service::Kanbanize < Service
   maintained_by :github => 'DanielDraganov'
   supported_by  :email => 'office@kanbanize.com'
 
-  def receive_push
+  def receive_event
     # Make sure that the api key is provided.
     raise_config_error "Missing 'kanbanize_api_key'" if data['kanbanize_api_key'].to_s == ''
-    
+	
     domain_name = data['kanbanize_domain_name']
     api_key = data['kanbanize_api_key']
     branch_restriction = data['restrict_to_branch'].to_s
     commit_restriction = config_boolean_true?('restrict_to_last_commit')
-    
+    issues_tracking = config_boolean_true?('track_project_issues_in_kanbanize')
+    issues_board_id = data['project_issues_board_id'].to_s
+	
     # check the branch restriction is poplulated and branch is not included
     branch = payload['ref'].split('/').last
     if branch_restriction.length > 0 && branch_restriction.index(branch) == nil
       return
     end
 
-     http_post "http://#{domain_name}/index.php/api/kanbanize/git_hub_event",
+    http_post "http://#{domain_name}/index.php/api/kanbanize/git_hub_event",
       generate_json(payload),
       'apikey' => api_key,
       'branch-filter' => branch_restriction,
       'last-commit' => commit_restriction,
+      'track-issues' => issues_tracking,
+      'board-id' => issues_board_id,
       'Content-Type' => 'application/json'
   end
 end

--- a/test/kanbanize_test.rb
+++ b/test/kanbanize_test.rb
@@ -12,13 +12,15 @@ class KanbanizeTest < Service::TestCase
       assert_equal '/index.php/api/kanbanize/git_hub_event', env[:url].request_uri
       assert_equal %({"ref":"refs/heads/master"}), env[:body]
       assert_equal 'a1b2c3==', env[:request_headers]['apikey']
-      assert_equal nil, env[:request_headers]['restrict_to_branch']
-      assert_equal nil, env[:request_headers]['restrict_to_last_commit']
+      assert_equal '', env[:request_headers]['branch-filter']
+      assert_equal false, env[:request_headers]['last-commit']
+      assert_equal false, env[:request_headers]['track-issues']
+      assert_equal '', env[:request_headers]['board-id']
       [200, {}, '']
     end
 
     svc = service({'kanbanize_domain_name' => 'testdomain.kanbanize.com', 'kanbanize_api_key' => 'a1b2c3=='}, {'ref' => 'refs/heads/master'})
-    svc.receive_push
+    svc.receive_event
   end
 
   def test_push_with_restrictions
@@ -30,13 +32,32 @@ class KanbanizeTest < Service::TestCase
       assert_equal 'a1b2c3==', env[:request_headers]['apikey']
       assert_equal 'mybranch1,mybranch2', env[:request_headers]['branch-filter']
       assert_equal true, env[:request_headers]['last-commit']
+      assert_equal false, env[:request_headers]['track-issues']
+      assert_equal '', env[:request_headers]['board-id']
       [200, {}, '']
     end
 
     svc = service({'kanbanize_domain_name' => 'testdomain.kanbanize.com', 'kanbanize_api_key' => 'a1b2c3==', 'restrict_to_branch' => 'mybranch1,mybranch2', 'restrict_to_last_commit' => '1'}, {'ref' => 'refs/heads/mybranch2'})
-    svc.receive_push
+    svc.receive_event
   end
 
+  def test_push_with_issue_tracking
+    url = '/index.php/api/kanbanize/git_hub_event'
+    @stubs.post url do |env|
+      assert_equal 'testdomain.kanbanize.com', env[:url].host
+      assert_equal '/index.php/api/kanbanize/git_hub_event', env[:url].request_uri
+      assert_equal %({"ref":"refs/heads/mybranch2"}), env[:body]
+      assert_equal 'a1b2c3==', env[:request_headers]['apikey']
+      assert_equal '', env[:request_headers]['branch-filter']
+      assert_equal false, env[:request_headers]['last-commit']
+      assert_equal true, env[:request_headers]['track-issues']
+      assert_equal '131', env[:request_headers]['board-id']
+      [200, {}, '']
+    end
+	
+    svc = service({'kanbanize_domain_name' => 'testdomain.kanbanize.com', 'kanbanize_api_key' => 'a1b2c3==', 'track_project_issues_in_kanbanize' => '1', 'project_issues_board_id' => '131'}, {'ref' => 'refs/heads/mybranch2'})
+    svc.receive_event
+  end
 
   def service(*args)
     super Service::Kanbanize, *args


### PR DESCRIPTION
The Kanbanize service now allows GitHub project issues tracking in a Kanbanize board.
When an issue is created or closed, a card will be created or moved to Done in a specified board.