### PR TITLE
Push commit info to JIRA as comment

### DIFF
--- a/docs/jira
+++ b/docs/jira
@@ -1,4 +1,4 @@
-This service hook allows you to transition JIRA tickets using the REST API available in
+This service hook allows you to transition JIRA tickets and post comments using the REST API available in
 version 4.2+ of JIRA. To interact with tickets in JIRA you will need to place markup
 similar to Lighthouse's in your commit message.
 
@@ -6,6 +6,9 @@ similar to Lighthouse's in your commit message.
 
 This will perform transition 31 with a resolution code of 1 on the issue WEB-210. You can specify
 any key value pair with the `key:value` notation, but at the very least transition must be present.
+
+Additionally, the author, commit msg, and files-changed will be placed in a comment in the jira issue 
+if the "Post comments" checkbox is selected.  A transition is not required for this.
 
 NOTE: As of 2.0.alpha1, the REST API will not automatically interpret strings into integers and vice
 versa.

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -1,7 +1,7 @@
 class Service::JIRA < Service
   string   :server_url, :api_version, :username
   password :password
-  boolean :post_comments
+  boolean :post_comments, :verify_ssl
   white_list :api_version, :server_url, :username, :post_comments
 
   logo_url "https://www.atlassian.com/wac/software/jira/productLogo/imageBinary/jira_logo_landing.png"
@@ -57,8 +57,7 @@ class Service::JIRA < Service
         next unless (changeset.has_key?(:transition) or config_boolean_true?('post_comments'))
 
         begin
-          # :(
-          http.ssl[:verify] = false
+          http.ssl[:verify] = verify_ssl
 
           http.basic_auth data['username'], data['password']
           http.headers['Content-Type'] = 'application/json'

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -1,13 +1,28 @@
 class Service::JIRA < Service
   string   :server_url, :api_version, :username
   password :password
-  white_list :api_version, :server_url, :username
+  boolean :post_comments
+  white_list :api_version, :server_url, :username, :post_comments
 
   def receive_push
     payload['commits'].each do |commit|
       next if commit['message'] =~ /^x /
 
+      author_display = "#{commit['author']['name']} <#{commit['author']['email']}>"
       comment_body = "#{commit['message']}\n#{commit['url']}"
+      files_changed = "\n"
+
+      # list each updated file's status in this commit
+      if config_boolean_true?('post_comments')
+        status_idx = [['A','added'],['D','removed'],['M','modified']]
+
+        # store in files_changed for post
+        status_idx.each do |abbr,file_st|
+          commit["#{file_st}"].each do |file|
+            files_changed.concat("#{abbr}\t#{file}\n")
+          end
+        end
+      end #if
 
       commit['message'].match(/\[#(.+)\]/)
       # Don't need to continue if we don't have a commit message containing JIRA markup
@@ -31,7 +46,7 @@ class Service::JIRA < Service
       end
 
       # Don't need to continue if we don't have a transition to perform
-      next unless changeset.has_key?(:transition)
+      next unless (changeset.has_key?(:transition) or config_boolean_true?('post_comments'))
 
       begin
         # :(
@@ -39,8 +54,16 @@ class Service::JIRA < Service
 
         http.basic_auth data['username'], data['password']
         http.headers['Content-Type'] = 'application/json'
-        res = http_post '%s/rest/api/%s/issue/%s/transitions' % [data['server_url'], data['api_version'], issue_id],
-          generate_json(changeset)
+        if changeset.has_key?(:transition)
+            res = http_post '%s/rest/api/%s/issue/%s/transitions' % [data['server_url'], data['api_version'], issue_id],
+              generate_json(changeset)
+        end
+
+        # add a comment containing the author, msg, and files changed
+        if config_boolean_true?('post_comments')
+              res = http_post '%s/rest/api/%s/issue/%s/comment' % [data['server_url'], data['api_version'], issue_id],
+              generate_json({ :body => "#{author_display}\n\n#{comment_body}\n\n#{files_changed}"})
+        end
       rescue URI::InvalidURIError
         raise_config_error "Invalid server_hostname: #{data['server_url']}"
       end

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -4,6 +4,11 @@ class Service::JIRA < Service
   boolean :post_comments
   white_list :api_version, :server_url, :username, :post_comments
 
+  logo_url "https://www.atlassian.com/wac/software/jira/productLogo/imageBinary/jira_logo_landing.png"
+
+  # i'd like to help improve this service
+  maintained_by :github => 'elordahl'
+
   def receive_push
     payload['commits'].each do |commit|
       next if commit['message'] =~ /^x /


### PR DESCRIPTION
Having commit information posted directly to a JIRA ticket is extremely convenient.  

These changes will enable GitHub to push the author, commit message, commit-url, and changed files directly to the JIRA ticket specified in the commit message.  It does so by creating a comment as the user specified in the service configuration.

I made these changes without modifying any of the existing functionality, but have added myself as a maintainer with hope of improving this plugin.  I've also added the URL to the logo.
