### PR TITLE
Respect AWS region in AWS CodeDeploy hook

### DIFF
--- a/lib/services/aws_code_deploy.rb
+++ b/lib/services/aws_code_deploy.rb
@@ -113,7 +113,12 @@ class Service::AwsCodeDeploy < Service::HttpPost
   end
 
   def custom_aws_region
-    code_deploy_aws_region || 'us-east-1'
+    return code_deploy_aws_region if code_deploy_aws_region
+    if config_value('aws_region').empty?
+      'us-east-1'
+    else
+      config_value('aws_region')
+    end
   end
 
   def stubbed_responses?


### PR DESCRIPTION
This fixes a bug that ignores the AWS region when using the AWS CodeDeploy hook.  Previously, the us-east-1 region was always used even if a different region was set in the hook settings.  Technically a region could be provided via a very specific deployment payload option, but this was not documented anywhere and not obvious.

When trying to deploy to a different AWS region, the service hook fails with no helpful error messages.  For example, see: https://forums.aws.amazon.com/thread.jspa?messageID=597193  Under the hood, this is failing because the CodeDeploy application does not exist in us-east-1.

This fixes the code to use the aws_region configuration value. Everything still defaults to us-east-1 if not set, and the undocumented custom codedeploy payload is still supported.