### PR TITLE
update README badge to link to Travis

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -8,4 +8,4 @@ for instructions on contributing a service.
 
 Current Status
 ==============
-![Build Status](https://travis-ci.org/github/github-services.svg)
+[![Build Status](https://travis-ci.org/github/github-services.svg?branch=master)](https://travis-ci.org/github/github-services)


### PR DESCRIPTION
Trivial, current badge links to the badge itself instead of the build
status on TravisCI.