### PR TITLE
set flag to exit script if any command fails

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Usage: script/bootstrap
 # Ensures all gems are in vendor/cache and installed locally.
+set -e
 
 bundle install --binstubs --local --path=vendor/gems
 bundle package --all
-


### PR DESCRIPTION
When running the `script/bootstrap` command on a Ruby version that is
not supported yet (2.2.0), the script experienced a failure during the
first step, trying to install eventmachine 1.0.3.

The eventmachine gem has since been updated to support building on Ruby
2.2.0 (See https://github.com/eventmachine/eventmachine/pull/503 for
details), however the bootstrap script itself should have stopped at
that point, surfacing the error to the operator to examine.