### PR TITLE
ignore any direnv config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 pkg
 .ruby-version
 .iml
+.envrc


### PR DESCRIPTION
direnv allows a user to auto-export environment variables that exist in
an .envrc file. This is useful to set up an environment
per-project-directory, and may contain credentials and other items
unsuited to sharing.