### PR TITLE
Fixed error in markdown to better visualize optional steps

### DIFF
--- a/docs/packagist
+++ b/docs/packagist
@@ -6,7 +6,8 @@ Install Notes
   1.  Create an account on packagist.org
   2.  Enter your credentials
       - The token which you can find on the Packagist profile page
-      Optional steps:
+
+    Optional steps:
       - Enter the username who the API token belongs to (defaults to the repository owner)
       - Enter the host of your Packagist installation (defaults to http://packagist.org), the protocol-prefix is optional and defaults to "http://".
 

--- a/docs/packagist
+++ b/docs/packagist
@@ -11,7 +11,7 @@ Install Notes
       - Enter the username who the API token belongs to (defaults to the repository owner)
       - Enter the host of your Packagist installation (defaults to http://packagist.org), the protocol-prefix is optional and defaults to "http://".
 
-  3.  Check the "Active" checkbox and click "Update Settings".
+  3.  Check the "Active" checkbox and click "Update Service".
 
 For more details about Packagist, visit http://packagist.org/
 


### PR DESCRIPTION
Only when reading these docs carefully I noticed the first entry had "Optional steps" stuck on the end of the sentence.