### PR TITLE
add Datadog service hook

### DIFF
--- a/docs/datadog
+++ b/docs/datadog
@@ -1,0 +1,17 @@
+Datadog is a monitoring service for IT, Operations and Development teams who
+write and run applications at scale, and want to turn the massive amounts of
+data produced by their apps, tools and services into actionable insight.
+
+This service hook will inform Datadog every time you push to GitHub.
+On every push Datadog will create an event in your account's timeline, enabling
+visual overlay of commits and pushes over time, and correlating these to other
+events.
+
+Install Notes
+-------------
+To add this repository to report to Datadog, follow these steps:
+
+1. Log into Datadog, and copy API Key from https://app.datadoghq.com/account/settings#api
+2. Paste your API Key in the text field above.
+3. (Optional) Set any tags as a comma-delimited list - each tag will be applied to every event.
+4. Make sure the "Active" checkbox is ticked, and click "Update Settings".

--- a/lib/services/datadog.rb
+++ b/lib/services/datadog.rb
@@ -1,0 +1,68 @@
+class Service::Datadog < Service::HttpPost
+  ## Company stuff
+  url 'https://app.datadoghq.com'
+  logo_url 'https://www.datadoghq.com/favicon.ico'
+
+  maintained_by :github => 'miketheman',
+                :twitter => '@mikefiedler'
+  # Support channels for user-level Datadog submission problems (service
+  # failure, misconfigured keys, etc)
+  supported_by :web => 'http://help.datadoghq.com/',
+               :email => 'support@datadoghq.com'
+  ## end Company
+
+  password :api_key
+  string :tags
+
+  # only include 'tags' in the debug logs, skip the api_key.
+  white_list :tags
+
+  default_events :push
+
+  def receive_push
+    # only handle pushes that include commits
+    return unless payload['commits']
+
+    api_key = required_config_value('api_key')
+    tags = config_value('tags')
+
+    post_event = format_event(payload)
+
+    # Tags are optional
+    post_event['tags'] = tags.split(',').map(&:strip) unless tags.nil?
+
+    http_post datadog_event_endpoint do |req|
+      req.params[:api_key] = api_key
+      req.body = generate_json(post_event)
+    end
+  end
+
+  private
+
+  def datadog_event_endpoint
+    'https://app.datadoghq.com/api/v1/events'
+  end
+
+  def format_event(payload)
+    # Parse out some interesting info from the payload
+    branch_name   = payload['ref'].split('/')[-1]
+    repo_name     = payload['repository']['url'].split('/')[-2..-1].join('/')
+    latest_commit = payload['commits'][-1]
+
+    event_title = "#{payload['pusher']['name']} pushed to #{branch_name} at #{repo_name}"
+
+    event_text = "There were #{payload['commits'].count} commits in this push.
+      Compare URL: #{payload['compare']}
+      Latest Commit by #{latest_commit['author']['name']}:
+      #{latest_commit['id'][0..7]} #{latest_commit['message']}"
+
+    post_event = {
+      'date_happened' => Time.now.to_i, # The time the push happened.
+      'priority' => 'normal',
+      'source_type_name' => 'github',
+      'text' => event_text,
+      'title' => event_title
+    }
+    post_event
+  end
+end

--- a/test/datadog_test.rb
+++ b/test/datadog_test.rb
@@ -1,0 +1,32 @@
+require File.expand_path('../helper', __FILE__)
+
+class DatadogTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+    @data = {
+      'api_key' => '123',
+      'tags' => 'environment:dev, test,  web:cluster1',
+    }
+  end
+
+  def test_push
+    assert '123', @data['api_key']
+    assert_includes @data['tags'], 'web:cluster1'
+
+    @stubs.post '/api/v1/events' do |env|
+      assert_equal 'app.datadoghq.com', env[:url].host
+
+      assert_match 'Latest Commit by Tom Preston-Werner', env[:body]
+      assert_match 'web:cluster1', env[:body]
+
+      [202, {}, '']
+    end
+
+    svc = service(@data, payload)
+    svc.receive_push
+  end
+
+  def service(*args)
+    super Service::Datadog, *args
+  end
+end


### PR DESCRIPTION
Hello Maintainers!

We'd like to (finally) ship a Datadog event integration to GitHub.

I've worked on this on-and-off for a while now, and we're currently still building out a generalized endpoint on Datadog-side to accept any generic GitHub payload, parse it and do the Right Thing.

However, we'd really appreciate it if you could review, comment and hopefully merge & deploy this current changeset, with the understanding that we are working on removing the need for most of the `format_event` method when our new endpoint is deployed.

Thanks for taking the time!

/cc: @degemer (who's working on the Datadog endpoint)
