### PR TITLE
Add filter_branch for commando.io service

### DIFF
--- a/docs/commandoio
+++ b/docs/commandoio
@@ -10,4 +10,4 @@ Install Notes
   * **Groups** - A list of group ids seperated by commas. You may find group ids in the modal popup when clicking a group in the Commando.io web interface.
   * **Notes** _(Optional)_ - Notes and comments you wish to attach to this execution. Markdown is supported.
   * **Halt on stderr** _(Optional)_ -  If a server returns stderr during execution, halt and prevent the remaining servers from executing the recipe.
-  * **Filter branch** _(Optional)_ -  If you would like to only receive messages for a specific branch, add the name (or partial name). Otherwise, leave the field blank to receive messages for all branches.
+  * **Filter branch** _(Optional)_ -  If you would like to only execute based on a specific branch, add the name (or partial name). Otherwise, leave the field blank to execute based off all branches.

--- a/docs/commandoio
+++ b/docs/commandoio
@@ -10,3 +10,4 @@ Install Notes
   * **Groups** - A list of group ids seperated by commas. You may find group ids in the modal popup when clicking a group in the Commando.io web interface.
   * **Notes** _(Optional)_ - Notes and comments you wish to attach to this execution. Markdown is supported.
   * **Halt on stderr** _(Optional)_ -  If a server returns stderr during execution, halt and prevent the remaining servers from executing the recipe.
+  * **Filter branch** _(Optional)_ -  If you would like to only receive messages for a specific branch, add the name (or partial name). Otherwise, leave the field blank to receive messages for all branches.

--- a/lib/services/commandoio.rb
+++ b/lib/services/commandoio.rb
@@ -70,7 +70,7 @@ class Service::Commandoio < Service::HttpPost
     filter_branch = data['filter_branch'].to_s
 
     # If filtering by branch then don't make a post
-    (filter_branch.length > 0) && (commit_branch.index(filter_branch) == nil)
+    ((filter_branch.length > 0) && (commit_branch.index(filter_branch) == nil)) ? false : true
   end
 
   # Validates the required config values

--- a/lib/services/commandoio.rb
+++ b/lib/services/commandoio.rb
@@ -24,10 +24,12 @@ class Service::Commandoio < Service::HttpPost
                 :recipe,
                 :server,
                 :groups,
-                :notes,
-                :filter_branch
+                :notes
 
   boolean       :halt_on_stderr
+
+  # filter_branch field at the end of the form
+  string        :filter_branch
 
   # Only include these in the debug logs
   white_list    :account_alias,


### PR DESCRIPTION
Hi :octocat:

This PR adds a form field to allow branch filtering in the service configuration. Mostly copied from `twitter.rb` ;)

Thanks!