### PR TITLE
Add netlify service

### DIFF
--- a/docs/netlify
+++ b/docs/netlify
@@ -1,0 +1,12 @@
+[Netlify](https://www.netlify.com) builds, deploys and hosts your static site or app.
+
+This hook gets added automatically when you link a site to a Github repository.
+
+Install Notes
+-------------
+
+1.  Sign up at https://www.netlify.com and start a new project
+2.  Authorize with Github and select the repository with your site
+3.  You're done!
+
+For more details about Netlify go to https://www.netlify.com

--- a/lib/services/netlify.rb
+++ b/lib/services/netlify.rb
@@ -1,0 +1,29 @@
+class Service::Netlify < Service
+  include HttpHelper
+
+  self.title = "Netlify"
+
+  url "https://www.netlify.com"
+  logo_url "https://www.netlify.com/favicon.ico"
+
+  maintained_by :github => 'netlify'
+  supported_by  :web => 'https://www.netlify.com/contact',
+    :email => 'support@netlify.com'
+
+  string :url
+
+  default_events :push, :pullrequest
+
+  def receive_event
+    http.headers['X-GitHub-Event'] = event.to_s
+    http.headers['X-GitHub-Delivery'] = delivery_guid.to_s
+
+    res = deliver data['url']
+
+    if res.status < 200 || res.status > 299
+      raise_config_error "Invalid HTTP Response: #{res.status}"
+    end
+  end
+
+  alias :original_body :payload
+end

--- a/test/netlify_test.rb
+++ b/test/netlify_test.rb
@@ -1,0 +1,25 @@
+require File.expand_path('../helper', __FILE__)
+
+class NetlifyTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_push
+    svc = service :push, {'url' => 'https://api.netlify.com/hooks/github'}, 'a' => 1
+
+    @stubs.post "/hooks/github" do |env|
+      assert_equal %({"a":1}), env[:body]
+      assert_equal 'application/json', env[:request_headers]['Content-Type']
+      [204, {}, '']
+    end
+
+    svc.receive
+
+    @stubs.verify_stubbed_calls
+  end
+
+  def service(*args)
+    super Service::Netlify, *args
+  end
+end


### PR DESCRIPTION
This adds a service hook for Netlify (https://www.netlify.com).

Netlify builds, deploys and hosts static sites and apps.

This service hook will be automatically configured when a user configures continuous deployment from Github to Netlify.