### PR TITLE
Avoid the regex for the default packagist domain

### DIFF
--- a/lib/services/packagist.rb
+++ b/lib/services/packagist.rb
@@ -38,8 +38,8 @@ class Service::Packagist < Service
     if data['domain'].to_s == ''
       'https://packagist.org'
     else
-      data['domain']
-    end.lstrip.sub(/[\/\s]+\z/,'').sub(/\Ahttp:\/\/packagist.org/, 'https://packagist.org')
+      data['domain'].lstrip.sub(/[\/\s]+\z/,'').sub(/\Ahttp:\/\/packagist.org/, 'https://packagist.org')
+    end
   end
 
   def domain_parts


### PR DESCRIPTION
The regex processing is not needed for the default value, only for values entered by the user