### PR TITLE
dashboard-next -> dashboard

### DIFF
--- a/lib/services/heroku_beta.rb
+++ b/lib/services/heroku_beta.rb
@@ -93,7 +93,7 @@ class Service::HerokuBeta < Service::HttpPost
   end
 
   def heroku_build_output_url(id)
-    "https://dashboard-next.heroku.com/apps/#{heroku_application_name}/activity/builds/#{id}"
+    "https://dashboard.heroku.com/apps/#{heroku_application_name}/activity/builds/#{id}"
   end
 
   def heroku_app_access?


### PR DESCRIPTION
Dashboard's URL changed a while ago. It'll redirect properly, but may as well point to the right place.