### PR TITLE
[OBS] Check Git reference before triggering build

### DIFF
--- a/docs/obs
+++ b/docs/obs
@@ -1,33 +1,45 @@
-Open Build Service(OBS) is a distribution build system.
+# Open Build Service
 
-By enabling this hook, any Open Build Service instance (running version 2.5 or higher) will list
-to push events. OBS Source Service will get execute for a defined package which will update
-the sources in OBS and therefore rebuild automatically.
+[Open Build Service (OBS)][obs] is a Web service for building packages for various Linux distributions. It's run by OpenSUSE project but available for any open-source community.
 
-Install Notes
--------------
+This hook enables you to trigger your OBS build once new commits are pushed into the repository. It is configured to use *api.opensuse.org* host by default, but you may use it for your own OBS instance as well. It must be version 2.5 or higher, though. 
 
-0. Prequire
-   You need to have a package using a source service to update the sources.
-   Check the OBS manual how to set this up.
+[obs]: http://build.opensuse.org
 
-1.  Create an authentification token for your account using "osc" commandline tool:
-    # osc token --create
+## Prerequisites
 
-    You may already specify the package here
-    # osc token --create _PROJECT_ _PACKAGE_
+1.  Configure your OBS project to fetch sources from Git. You would have to add a *Source Service* for this to work, check OBS manual for more information.
 
-    That means the token can only be used for this package. It also means you do not have
-    to specify it in github.com. Just using the token is enough.
+2.  Create an authentification token for your account using `osc` command line tool.
+    For a generic token not tied to the specific package:
 
-    You can also use a comma separated list of tokens to trigger several obs builds.
+         # osc token --create
 
-2.  Enter your credentials at github.com
-    - The token which got created (use "osc token" if you lost it)
-    - optional: Modify the api url, if you do not use the openSUSE Build Service instance.
-    - optional: Enter the project and package name in case you have a generic token.
+    For a token which can be used only for specific package
 
-3.  Make sure the "Active" checkbox is ticked, and click "Update Settings".
+         # osc token --create PROJECT PACKAGE
 
-For more details about OBS, go to http://www.openbuildservice.org
+    In the former case you may use single token in multiple Web hooks, to trigger multiple projects, but you would have to specify those OBS project and repository names. If the latter case you have to use different tokens for different projects, but you may leave "Project" and "Package" fields blank here, simply using the token only is enough.
 
+    To see all your already-created tokens, run
+
+        # osc token
+
+    You may also use a comma-separated list of tokens to trigger several OBS builds in order.
+
+## Parameters
+
+  - `Url`
+    This is the URL where OBS instance resides. You should alter this parameter only if you're using a dedicated OBS instance, leave it empty if you just use OpenSUSE's server. 
+
+  - `Project`
+    The package fully-qualified name on the instance. This should be something like `devel:languages:haskell`, where `devel:languages` is a namespace part of name. You may leave this field blank if your token is project-specific.
+
+  - `Package`
+    The package name within the project. This should be something like `ghc` for the example above. You may also leave this field blank if your token is project-specific.
+
+  - `Token`
+    The comma-separated list of tokens to be used for triggering builds. This is the only required field here. See the "Prerequisites" section for more information on token creation.
+
+  - `Refs`
+    The filter expression for pushed referenced. This field lists colon-separated patterns, build is triggered only if at least one of them satisfies. You may leave it blank, then no filtering is done by default. But you should consider setting this field to something like `refs/heads/master` or `refs/tags/version-*` in order not to rebuild your packages on each commit.

--- a/lib/services/obs.rb
+++ b/lib/services/obs.rb
@@ -1,8 +1,8 @@
 class Service::Obs < Service::HttpPost
-  string :url, :project, :package
+  string :url, :project, :package, :refs
   password :token
 
-  white_list :url, :project, :package
+  white_list :url, :project, :package, :refs
 
   default_events :push
 
@@ -23,6 +23,15 @@ class Service::Obs < Service::HttpPost
     # optional. The token may set the package container already.
     project = config_value('project')
     package = config_value('package')
+
+    # optional. Do not filter references by default.
+    refs = config_value('refs')
+
+    if refs.present?
+      return unless refs.split(":").any? do |pattern|
+        File::fnmatch(pattern, ref)
+      end
+    end
 
     # multiple tokens? handle each one individually
     token.split(",").each do |t|

--- a/test/obs_test.rb
+++ b/test/obs_test.rb
@@ -27,6 +27,16 @@ class ObsTest < Service::TestCase
     }
   end
 
+  def filter_data
+    {
+      "url" => "http://api.opensuse.org:443",
+      "token" => "github/test/token/string",
+      "project" => "home:adrianSuSE",
+      "package" => "4github",
+      "refs" => "refs/tags/version-*:refs/heads/production",
+    }
+  end
+
   def test_push_single_token
     apicall = "/trigger/runservice"
     @stubs.post apicall do |env|
@@ -60,8 +70,57 @@ class ObsTest < Service::TestCase
     assert_equal match, 2
   end
 
+  def test_filter_passed_by_tag
+    apicall = "/trigger/runservice"
+    @stubs.post apicall do |env|
+      assert_equal 'api.opensuse.org', env[:url].host
+      params = Faraday::Utils.parse_query env[:body]
+      assert_equal 'Token github/test/token/string', env[:request_headers]["Authorization"]
+      assert_equal '/trigger/runservice', env[:url].path
+      assert_equal 'package=4github&project=home%3AadrianSuSE', env[:url].query
+      [200, {}, '']
+    end
+
+    # Modify the payload to match the filter.
+    pay = payload
+    pay['ref'] = 'refs/tags/version-1.1'
+
+    svc = service :push, filter_data, pay
+    assert svc.receive
+    @stubs.verify_stubbed_calls
+  end
+
+  def test_filter_passed_by_branch
+    apicall = "/trigger/runservice"
+    @stubs.post apicall do |env|
+      assert_equal 'api.opensuse.org', env[:url].host
+      params = Faraday::Utils.parse_query env[:body]
+      assert_equal 'Token github/test/token/string', env[:request_headers]["Authorization"]
+      assert_equal '/trigger/runservice', env[:url].path
+      assert_equal 'package=4github&project=home%3AadrianSuSE', env[:url].query
+      [200, {}, '']
+    end
+
+    # Modify the payload to match the filter.
+    pay = payload
+    pay['ref'] = 'refs/heads/production'
+
+    svc = service :push, filter_data, pay
+    svc.receive
+    @stubs.verify_stubbed_calls
+  end
+
+  def test_filter_rejected
+    apicall = "/trigger/runservice"
+    @stubs.post apicall do |env|
+      flunk "Master branch should not trigger post request"
+    end
+
+    svc = service :push, filter_data, payload
+    svc.receive
+  end
+
   def service(*args)
     super Service::Obs, *args
   end
 end
-


### PR DESCRIPTION
This pull request introduces a new parameter `refs` for Open Build Service (OBS) webhook. It can hold a colon-separated list of wildcard patterns for Git references to be checked against. Push only triggers a build action if its reference matched at least one of these patterns. For example, if `refs` has value `refs/heads/production:refs/tags/version-*`, then:

* pushing commits into `master` branch won't trigger build, as `refs/heads/master` matches neither `refs/heads/production` nor `refs/tags/version-*`;
* but pushing commits into `production` branch triggers build;
* and pushing tags starting with `version-` triggers build too.

Please, let me know about *anything* I can improve in this patch as I program in Ruby only very occasionally.

**P. S.**
Is it a good idea to also rename the hook from "Obs" to "OBS"? Is this doable at all without breaking existing repositories settings?