### PR TITLE
email: Get rid of useless indent.

### DIFF
--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -104,7 +104,7 @@ class Service::Email < Service
     text.slice(0, limit) << '...'
   end
 
-  def align(text, indent = '  ')
+  def align(text, indent = '')
     margin = text[/\A\s+/].size
 
     text.gsub(/^\s{#{margin}}/, indent)


### PR DESCRIPTION
There's no point in having this, and it just creates annoyances for the recipients.

Apologies if this is incorrect; I'm not really a Ruby programmer.