### PR TITLE
Fixes typo: verfiy_ssl -> verify_ssl

### DIFF
--- a/docs/gocd
+++ b/docs/gocd
@@ -17,5 +17,5 @@ Install Notes
 4. "username" and "password" - username and password of a Go admin user that can
    trigger the Materials API endpoint. Can be left empty if the Go server has no authentication configured (not recommended.)
 
-5. "verfiy_ssl" is used to enable (recommended) or disable certificate checking when using ssl.
+5. "verify_ssl" is used to enable (recommended) or disable certificate checking when using ssl.
    Disabling this can make the ssl connection insecure.


### PR DESCRIPTION
Just an update to the docs for the GoCD service integration to correct a typo.