### PR TITLE
irc service: Append GitHub username and repository to realname

### DIFF
--- a/lib/service/events/push_helpers.rb
+++ b/lib/service/events/push_helpers.rb
@@ -180,7 +180,8 @@ module Service::PushHelpers
         "url"   => "http://github.com/mojombo/grit",
         "owner" => { "name" => "mojombo", "email" => "tom@mojombo.com" },
         "master_branch"  => "master",
-        "default_branch" => "master"
+        "default_branch" => "master",
+        "private" => false
       },
 
       "pusher" => {

--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -138,7 +138,10 @@ class Service::IRC < Service
   end
 
   def irc_realname
-    (defined?(sender) && defined?(repo)) ? "GitHub IRCBot - #{sender.login}/#{repo.name}" : "Github IRCBot"
+    repo_owner = payload["repository"]["owner"]["name"]
+    repo_name = payload["repository"]["name"]
+
+    "GitHub IRCBot - #{repo_owner}/#{repo_name}"
   end
 
   def debug_outgoing(command)

--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -141,7 +141,23 @@ class Service::IRC < Service
     repo_owner = payload["repository"]["owner"]["name"]
     repo_name = payload["repository"]["name"]
 
-    "GitHub IRCBot - #{repo_owner}/#{repo_name}"
+    "GitHub IRCBot - #{repo_owner}" + (repo_public? ? "/#{repo_name}" : "")
+  end
+
+  def repo_public?
+    return @repo_public if defined?(@repo_public)
+
+    repo_owner = payload["repository"]["owner"]["name"]
+    repo_name = payload["repository"]["name"]
+    return false if repo_owner.to_s.empty? || repo_name.to_s.empty?
+    
+    http.url_prefix = "https://api.github.com"
+    begin
+      response = http_get("/repos/#{repo_owner}/#{repo_name}")
+      @repo_public = (defined?(response.body[:id]) && response.status == 200)
+    rescue
+      @repo_public = false
+    end
   end
 
   def debug_outgoing(command)

--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -140,26 +140,9 @@ class Service::IRC < Service
   def irc_realname
     repo_owner = payload["repository"]["owner"]["name"]
     repo_name = payload["repository"]["name"]
+    repo_private = payload["repository"]["private"]
 
-    "GitHub IRCBot - #{repo_owner}" + (repo_public? ? "/#{repo_name}" : "")
-  end
-
-  def repo_public?
-    return @repo_public if defined?(@repo_public)
-
-    repo_owner = payload["repository"]["owner"]["name"]
-    repo_name = payload["repository"]["name"]
-    return false if repo_owner.to_s.empty? || repo_name.to_s.empty?
-    
-    http.url_prefix = "https://api.github.com"
-    begin
-      response = http_get("/repos/#{repo_owner}/#{repo_name}")
-      json = JSON.parse(response.body)
-
-      @repo_public = (defined?(json["id"]) && response.status == 200)
-    rescue
-      @repo_public = false
-    end
+    "GitHub IRCBot - #{repo_owner}" + (repo_private ? "" : "/#{repo_name}")
   end
 
   def debug_outgoing(command)

--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -142,7 +142,7 @@ class Service::IRC < Service
     repo_name = payload["repository"]["name"]
     repo_private = payload["repository"]["private"]
 
-    "GitHub IRCBot - #{repo_owner}" + (repo_private ? "" : "/#{repo_name}")
+    "GitHub IRCBot - #{repo_owner}" + (repo_private == true ? "" : "/#{repo_name}")
   end
 
   def debug_outgoing(command)

--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -142,7 +142,7 @@ class Service::IRC < Service
     repo_name = payload["repository"]["name"]
     repo_private = payload["repository"]["private"]
 
-    "GitHub IRCBot - #{repo_owner}" + (repo_private != true ? "/#{repo_name}" : "")
+    "GitHub IRCBot - #{repo_owner}" + (repo_private == false ? "/#{repo_name}" : "")
   end
 
   def debug_outgoing(command)

--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -58,11 +58,10 @@ class Service::IRC < Service
     rooms   = rooms.gsub(",", " ").split(" ").map{|room| room[0].chr == '#' ? room : "##{room}"}
     botname = data['nick'].to_s.empty? ? "GitHub#{rand(200)}" : data['nick'][0..16]
     command = config_boolean_true?('notice') ? 'NOTICE' : 'PRIVMSG'
-    geckos  = (defined?(sender) && defined?(repo)) ? "GitHub IRCBot - #{sender.login}/#{repo.name}" : "Github IRCBot"
 
     irc_password("PASS", data['password']) if !data['password'].to_s.empty?
     irc_puts "NICK #{botname}"
-    irc_puts "USER #{botname} 8 * :#{geckos}"
+    irc_puts "USER #{botname} 8 * :#{irc_realname}"
 
     loop do
       case irc_gets
@@ -136,6 +135,10 @@ class Service::IRC < Service
   def irc_puts(command, debug_command=command)
     debug_outgoing(debug_command)
     writable_irc.puts command
+  end
+
+  def irc_realname
+    (defined?(sender) && defined?(repo)) ? "GitHub IRCBot - #{sender.login}/#{repo.name}" : "Github IRCBot"
   end
 
   def debug_outgoing(command)

--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -58,10 +58,11 @@ class Service::IRC < Service
     rooms   = rooms.gsub(",", " ").split(" ").map{|room| room[0].chr == '#' ? room : "##{room}"}
     botname = data['nick'].to_s.empty? ? "GitHub#{rand(200)}" : data['nick'][0..16]
     command = config_boolean_true?('notice') ? 'NOTICE' : 'PRIVMSG'
+    geckos  = (defined?(sender) && defined?(repo)) ? "GitHub IRCBot - #{sender.login}/#{repo.name}" : "Github IRCBot"
 
     irc_password("PASS", data['password']) if !data['password'].to_s.empty?
     irc_puts "NICK #{botname}"
-    irc_puts "USER #{botname} 8 * :GitHub IRCBot"
+    irc_puts "USER #{botname} 8 * :#{geckos}"
 
     loop do
       case irc_gets

--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -142,7 +142,7 @@ class Service::IRC < Service
     repo_name = payload["repository"]["name"]
     repo_private = payload["repository"]["private"]
 
-    "GitHub IRCBot - #{repo_owner}" + (repo_private == true ? "" : "/#{repo_name}")
+    "GitHub IRCBot - #{repo_owner}" + (repo_private != true ? "/#{repo_name}" : "")
   end
 
   def debug_outgoing(command)

--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -154,7 +154,9 @@ class Service::IRC < Service
     http.url_prefix = "https://api.github.com"
     begin
       response = http_get("/repos/#{repo_owner}/#{repo_name}")
-      @repo_public = (defined?(response.body[:id]) && response.status == 200)
+      json = JSON.parse(response.body)
+
+      @repo_public = (defined?(json["id"]) && response.status == 200)
     rescue
       @repo_public = false
     end

--- a/test/irc_test.rb
+++ b/test/irc_test.rb
@@ -311,6 +311,17 @@ class IRCTest < Service::TestCase
     assert_includes msgs, "USER n 8 * :GitHub IRCBot - mojombo"
   end
 
+  def test_nil_private_repo_format_in_irc_realname
+    payload_copy = payload.clone
+    payload_copy["repository"]["private"] = nil
+    svc = service({'room' => 'r', 'nick' => 'n'}, payload_copy)
+
+    svc.receive_push
+    msgs = svc.writable_irc.string.split("\n")
+
+    assert_includes msgs, "USER n 8 * :GitHub IRCBot - mojombo"
+  end
+
   def service(*args)
     super FakeIRC, *args
   end

--- a/test/irc_test.rb
+++ b/test/irc_test.rb
@@ -4,9 +4,9 @@ require 'stringio'
 class IRCTest < Service::TestCase
   def setup
     @stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-      stub.get('/repos/mojombo/grit') { |env| [200, {}, {id: 1}] }
-      stub.get('/repos/mojombo/public') { |env| [200, {}, {id: 1}] }
-      stub.get('/repos/mojombo/private') { |env| [404, {}, {message: "Not Found"}] }
+      stub.get('/repos/mojombo/grit') { |env| [200, {}, '{"id": 1}'] }
+      stub.get('/repos/mojombo/public') { |env| [200, {}, '{"id": 1}'] }
+      stub.get('/repos/mojombo/private') { |env| [404, {}, '{"message": "Not Found"}'] }
     end
   end
 
@@ -321,15 +321,17 @@ class IRCTest < Service::TestCase
 
   def test_is_public_repo_on_public_repo
     @stubs.get "/repos/mojombo/public" do |env|
+      json = JSON.parse(env.body)
       assert_equal env.status, 200
-      assert_equal env.body[:id], 1
+      assert_equal json["id"], 1
     end
   end
 
   def test_is_public_repo_on_private_repo
     @stubs.get "/repos/mojombo/private" do |env|
+      json = JSON.parse(env.body)
       assert_equal env.status, 404
-      assert defined?(env.body[:id]), false
+      assert defined?(json["id"]), false
     end
   end
 

--- a/test/irc_test.rb
+++ b/test/irc_test.rb
@@ -291,6 +291,14 @@ class IRCTest < Service::TestCase
     refute_match /\003/, privmsg
   end
 
+  def test_include_repo_name_and_owner_in_irc_realname
+    svc = service(:pull_request, {'room' => 'r', 'nick' => 'n'}, pull_payload)
+
+    svc.receive_pull_request
+    msgs = svc.writable_irc.string.split("\n")
+    assert_includes msgs, "USER n 8 * :GitHub IRCBot - defunkt/grit"
+  end
+
   def service(*args)
     super FakeIRC, *args
   end

--- a/test/irc_test.rb
+++ b/test/irc_test.rb
@@ -2,6 +2,14 @@ require File.expand_path('../helper', __FILE__)
 require 'stringio'
 
 class IRCTest < Service::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get('/repos/mojombo/grit') { |env| [200, {}, {id: 1}] }
+      stub.get('/repos/mojombo/public') { |env| [200, {}, {id: 1}] }
+      stub.get('/repos/mojombo/private') { |env| [404, {}, {message: "Not Found"}] }
+    end
+  end
+
   class FakeIRC < Service::IRC
     def readable_irc
       nick = data['nick']
@@ -291,12 +299,38 @@ class IRCTest < Service::TestCase
     refute_match /\003/, privmsg
   end
 
-  def test_include_repo_name_and_owner_in_irc_realname
+  def test_public_repo_format_in_irc_realname
     svc = service({'room' => 'r', 'nick' => 'n'}, payload)
 
     svc.receive_push
     msgs = svc.writable_irc.string.split("\n")
+
     assert_includes msgs, "USER n 8 * :GitHub IRCBot - mojombo/grit"
+  end
+
+  def test_private_repo_format_in_irc_realname
+    payload_copy = payload.clone
+    payload_copy["repository"]["name"] = "private"
+    svc = service({'room' => 'r', 'nick' => 'n'}, payload_copy)
+
+    svc.receive_push
+    msgs = svc.writable_irc.string.split("\n")
+
+    assert_includes msgs, "USER n 8 * :GitHub IRCBot - mojombo"
+  end
+
+  def test_is_public_repo_on_public_repo
+    @stubs.get "/repos/mojombo/public" do |env|
+      assert_equal env.status, 200
+      assert_equal env.body[:id], 1
+    end
+  end
+
+  def test_is_public_repo_on_private_repo
+    @stubs.get "/repos/mojombo/private" do |env|
+      assert_equal env.status, 404
+      assert defined?(env.body[:id]), false
+    end
   end
 
   def service(*args)

--- a/test/irc_test.rb
+++ b/test/irc_test.rb
@@ -292,11 +292,11 @@ class IRCTest < Service::TestCase
   end
 
   def test_include_repo_name_and_owner_in_irc_realname
-    svc = service(:pull_request, {'room' => 'r', 'nick' => 'n'}, pull_payload)
+    svc = service({'room' => 'r', 'nick' => 'n'}, payload)
 
-    svc.receive_pull_request
+    svc.receive_push
     msgs = svc.writable_irc.string.split("\n")
-    assert_includes msgs, "USER n 8 * :GitHub IRCBot - defunkt/grit"
+    assert_includes msgs, "USER n 8 * :GitHub IRCBot - mojombo/grit"
   end
 
   def service(*args)

--- a/test/irc_test.rb
+++ b/test/irc_test.rb
@@ -301,7 +301,7 @@ class IRCTest < Service::TestCase
   end
 
   def test_private_repo_format_in_irc_realname
-    payload_copy = payload.clone
+    payload_copy = payload
     payload_copy["repository"]["private"] = true
     svc = service({'room' => 'r', 'nick' => 'n'}, payload_copy)
 
@@ -312,7 +312,7 @@ class IRCTest < Service::TestCase
   end
 
   def test_nil_private_repo_format_in_irc_realname
-    payload_copy = payload.clone
+    payload_copy = payload
     payload_copy["repository"]["private"] = nil
     svc = service({'room' => 'r', 'nick' => 'n'}, payload_copy)
 


### PR DESCRIPTION
This gives network and channel staff a pointer in case a github bot is at the wrong channel.

Due to how IRC works, if a specific configuration is causing issues, network staff will have no way to know who is hosting the bot (it disconnects too fast to know which channel it tried to join). Adding the github-username/repository string in the realname will allow them to investigate the situation and attempt to contact the user.

This change is minimalistic, and I have ensured that it falls back to the original value if the data is unavailable. The tests appear to be functional and I have confirmed with dummy data that this change does work.

Fixes https://github.com/github/github-services/issues/1016 if implemented.

I hope you consider this pull request.