### PR TITLE
Clarify refs can be used for IRC

### DIFF
--- a/docs/irc
+++ b/docs/irc
@@ -49,7 +49,7 @@ Nickname to use when sending messages (optional).
 
 ### Branches
 
-Names of the git branches to monitor for events (comma-separated).
+Names of the git branches (or refs) to monitor for events (comma-separated).
 
 
 ### Nickserv password


### PR DESCRIPTION
Fixes #773. You can use `refs` such as tags in addition to branches in the IRC service. This PR merely adds that to the documentation.