### PR TITLE
Toggl service update

### DIFF
--- a/docs/toggl
+++ b/docs/toggl
@@ -1,4 +1,4 @@
-1. API Key: Your toggl api key.  (Get it at https://www.toggl.com/user/edit)
+1. API Key: Your toggl api key.  (Get it at https://toggl.com/app/profile)
 2. Project: the id of the toggl project that this repo links to
 3. Activate and go!
 4. To track your time simply add t:number-of-minutes (integer) to your commit message

--- a/lib/services/toggl.rb
+++ b/lib/services/toggl.rb
@@ -14,21 +14,17 @@ class Service::Toggl < Service
 
       # Toggl wants it in seconds.  Commits should be in seconds
       duration = duration.to_i * 60
-
-      http_post "tasks.json", generate_json(
-        :task => {
+      http_post "time_entries", generate_json(
+        :time_entry => {
           :duration => duration.to_i,
           :description => commit["message"].strip,
-          :project => {
-            :id => data["project"]
-          },
+          :pid => data["project"],
           :start => (Time.now - duration.to_i).iso8601,
-          :billable => true,
+          :billable => true, # this is a pro feature, will be ignored for free version users
           :created_with => "github",
           :stop => Time.now.iso8601
         }
       )
-
     end
   end
 end

--- a/test/toggl_test.rb
+++ b/test/toggl_test.rb
@@ -6,11 +6,11 @@ class TogglTest < Service::TestCase
   end
 
   def test_push
-    url = "/api/v8/tasks.json"
+    url = "/api/v8/time_entries"
     @stubs.post url do |env|
       assert_equal 'www.toggl.com', env[:url].host
       assert_equal basic_auth(:a, :api_token), env[:request_headers]['authorization']
-      assert_equal 900, JSON.parse(env[:body])['task']['duration']
+      assert_equal 900, JSON.parse(env[:body])['time_entry']['duration']
       [200, {}, '']
     end
 


### PR DESCRIPTION
This should address https://github.com/github/github-services/issues/1007

Basically tries to mimic the previous behaviour for version 6 of the API (deprecated today) by mapping existing functionality to current version.