### PR TITLE
Updating URL on Leanpub where you find your author API key

### DIFF
--- a/docs/leanpub
+++ b/docs/leanpub
@@ -2,7 +2,7 @@ This service starts a preview of your book on Leanpub whenever a push is made to
 
 Required values are:
 
-api_key: Your Leanpub api_key, which you can find at https://leanpub.com/dashboard/account.
+api_key: Your Leanpub api_key, which you can find at https://leanpub.com/author_dashboard/settings.
 
 slug: The slug for your book. This is the part of the URL for your book after https://leanpub.com/. For example, for https://leanpub.com/thes3cookbook, the slug is thes3cookbook.
 


### PR DESCRIPTION
Just a quick documentation fix. Thanks!