### PR TITLE
Twitter: Preserve commit message whitespace

### DIFF
--- a/lib/services/twitter.rb
+++ b/lib/services/twitter.rb
@@ -42,7 +42,7 @@ class Service::Twitter < Service
         url = commit['url']
         # Strip out leading @s so that github @ mentions don't become twitter @ mentions
         # since there's zero reason to believe IDs on one side match IDs on the other
-        message = commit['message'].gsub(/\B@[[:word:]]+/) do |word|
+        message = commit['message'].gsub(/\B[@＠][[:word:]]+/) do |word|
           "@\u200b#{word[1..word.length]}"
         end
         status = if short_format?

--- a/lib/services/twitter.rb
+++ b/lib/services/twitter.rb
@@ -42,9 +42,9 @@ class Service::Twitter < Service
         url = commit['url']
         # Strip out leading @s so that github @ mentions don't become twitter @ mentions
         # since there's zero reason to believe IDs on one side match IDs on the other
-        message = commit['message'].split(' ').map do |word|
-          (word.length > 1 && word[0] == '@') ? "@\u200b#{word[1..word.length]}" : word
-        end.join(' ')
+        message = commit['message'].gsub(/\B@[^ ]+/) do |word|
+          "@\u200b#{word[1..word.length]}"
+        end
         status = if short_format?
           "#{url} #{message}"
         else

--- a/lib/services/twitter.rb
+++ b/lib/services/twitter.rb
@@ -42,7 +42,7 @@ class Service::Twitter < Service
         url = commit['url']
         # Strip out leading @s so that github @ mentions don't become twitter @ mentions
         # since there's zero reason to believe IDs on one side match IDs on the other
-        message = commit['message'].gsub(/\B@[^ ]+/) do |word|
+        message = commit['message'].gsub(/\B@[[:word:]]+/) do |word|
           "@\u200b#{word[1..word.length]}"
         end
         status = if short_format?

--- a/lib/services/twitter.rb
+++ b/lib/services/twitter.rb
@@ -42,7 +42,7 @@ class Service::Twitter < Service
         url = commit['url']
         # Strip out leading @s so that github @ mentions don't become twitter @ mentions
         # since there's zero reason to believe IDs on one side match IDs on the other
-        message = commit['message'].gsub(/\B[@＠][[:word:]]+/) do |word|
+        message = commit['message'].gsub(/\B[@＠][[:word:]]/) do |word|
           "@\u200b#{word[1..word.length]}"
         end
         status = if short_format?

--- a/test/twitter_test.rb
+++ b/test/twitter_test.rb
@@ -52,6 +52,24 @@ class TwitterTest < Service::TestCase
     end
   end
 
+  # Make sure that whitespace in the original commit message is preserved
+  def test_whitespace
+    p = payload
+    p['commits'][0]['message']="message  \nwith\n\n  weird whitespace  "
+    svc = service({'token' => 't', 'secret' => 's'}, p)
+
+    def svc.statuses
+      @statuses ||= []
+    end
+
+    def svc.post(status)
+      statuses << status
+    end
+
+    svc.receive_push
+    assert svc.statuses[0].match(p['commits'][0]['message'])
+  end
+
   # Make sure that GitHub @mentions are injected with a zero-width space
   # so that they don't turn into (potentially unmatching) twitter @mentionds
   def test_mentions

--- a/test/twitter_test.rb
+++ b/test/twitter_test.rb
@@ -76,7 +76,7 @@ class TwitterTest < Service::TestCase
     p = payload
     p['commits'][0]['message']="This commit was done by @sgolemon"
     p['commits'][1]['message']="@sgolemon committed this"
-    p['commits'][2]['message']="@sgolemon made a test for @kdaigle"
+    p['commits'][2]['message']="@sgolemon made a @ @\ttest for @kdaigle"
     svc = service({'token' => 't', 'secret' => 's'}, p)
 
     def svc.statuses
@@ -90,9 +90,11 @@ class TwitterTest < Service::TestCase
     svc.receive_push
     assert_equal 3, svc.statuses.size
     svc.statuses.each do |st|
-      # Any @ which is not followed by U+200B ZERO WIDTH SPACE
-      # is an error
-      assert !st.match('@(?!\u200b)')
+      # Any @ which is followed by a word character is an error
+      assert !st.match('@(?=[[:word:]])')
+      # Any @ which is followed by a U+200b ZERO WIDTH SPACE but not a word
+      # character is an error
+      assert !st.match('@(?=\u200b[^[:word:]])')
     end
   end
 


### PR DESCRIPTION
When tweeting commit messages, preserve the original commit message whitespace and tweet it as-is.

Previously, `String#split(" ")` was used to process words, [which splits on *any* whitespace and with runs of contiguous whitespace characters ignored][1]. When the split array was turned back into a string with `Array#join(" ")`, original whitespace characters were lost and replaced by a single space character.

Now, `String#gsub` and a regular expression is used to process words, which will preserve the original whitespace.

Fixes #959.

/cc @domenic @kdaigle

[1]: http://ruby-doc.org/core-2.2.0/String.html#method-i-split