### PR TITLE
Update CI RBENV to match production

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -5,7 +5,7 @@
 
 test -d "/usr/share/rbenv/shims" && {
   export PATH=/usr/share/rbenv/shims:$PATH
-  export RBENV_VERSION="1.9.3-p231-tcs-github"
+  export RBENV_VERSION="2.1.6-github"
 }
 
 script/bootstrap


### PR DESCRIPTION
This updates the CI build Ruby version to the same in production. :sparkles: