### PR TITLE
Make Amazon services named consistently

### DIFF
--- a/docs/sqsqueue
+++ b/docs/sqsqueue
@@ -1,12 +1,12 @@
 Install Notes
 -------------
 
-SqsQueue allows GitHub to send a notification to a queue inside your Amazon AWS SQS service.
+The Amazon SQS service allows GitHub to send a notification to an Amazon SQS queue.
 
 1. Configure your Amazon AWS account with an appropriately set up access-key/secret-key (Either parent account or IAM)
    that has permissions to perform 'SendMessage' operations. (https://console.aws.amazon.com/sqs/)
 
-2. Aws SQS ARN is the unique code SQS references your queue with. It can be copied from the console
+2. Amazon SQS ARN is the unique code SQS references your queue with. It can be copied from the console
    or fetched through the API. It takes the form of arn:aws:sqs:us-(region)-(dc):(id):(name). Copy and
    paste the entire string. This hook parses the necessary details from the arn.
    You may also specify a SQS Queue URL instead of an ARN if you want to use IAM or a Queue that was created using a different account.

--- a/lib/services/amazon_sns.rb
+++ b/lib/services/amazon_sns.rb
@@ -1,6 +1,7 @@
 require 'aws-sdk-core'
 
 class Service::AmazonSNS < Service
+  self.title = "Amazon SNS"
 
   string :aws_key, :sns_topic, :sns_region
 

--- a/lib/services/sqs_queue.rb
+++ b/lib/services/sqs_queue.rb
@@ -1,4 +1,6 @@
 class Service::SqsQueue < Service::HttpPost
+  self.title = "Amazon SQS"
+
   string :aws_access_key, :aws_sqs_arn
   password :aws_secret_key
   # NOTE: at some point, sqs_queue_name needs to be deprecated and removed


### PR DESCRIPTION
This fixes https://github.com/github/github-services/issues/1053 by using the exact brand names that Amazon uses for each of the services. I was going to just prefix them all with AWS but it appears that Amazon perfers AWS in some places and Amazon in others.

cc @pengwynn 