### PR TITLE
humbug: Add checkbox for emphasizing branch in topic.

### DIFF
--- a/docs/humbug
+++ b/docs/humbug
@@ -21,3 +21,4 @@ Checkboxes
 1. **Exclude Pull Requests** - Don't send GitHub pull request notifications to Zulip.
 2. **Exclude Issues** - Don't send GitHub issues notifications to Zulip.
 3. **Exclude Commits** - Don't send Git commit notifcations to Zulip.
+4. **Emphasize branch in topic** - Highlight branch instead of repo name in message topics.

--- a/lib/services/humbug.rb
+++ b/lib/services/humbug.rb
@@ -18,6 +18,7 @@ class Service::Humbug < Service
   boolean :exclude_pull_requests
   boolean :exclude_issues
   boolean :exclude_commits
+  boolean :emphasize_branch_in_topic
 
   # list of things approved for github's logging. See service.rb for more.
   white_list :email
@@ -26,6 +27,7 @@ class Service::Humbug < Service
   white_list :exclude_pull_requests
   white_list :exclude_issues
   white_list :exclude_commits
+  white_list :emphasize_branch_in_topic
 
   # events handled by this GitHub hook
   default_events :commit_comment, :create, :delete, :download, :follow, :fork,
@@ -58,6 +60,7 @@ class Service::Humbug < Service
           :exclude_pull_requests => data['exclude_pull_requests'],
           :exclude_issues => data['exclude_issues'],
           :exclude_commits => data['exclude_commits'],
+          :emphasize_branch_in_topic => data['emphasize_branch_in_topic'],
 
           :event => event,
           :payload => generate_json(payload),


### PR DESCRIPTION
I realize ordinarily you folks are not accepting feature changes; but for complicated reasons it'd be quite valuable for us to be able to get this one last feature change in (so we can stop hardcoding this for particular users on the backend) in a timely fashion.  I expect we'll be able to switch to the webhook based model before this needs to be modified again.  Thanks for your consideration!