### PR TITLE
dashboard-next -> dashboard

### DIFF
--- a/lib/services/heroku_beta.rb
+++ b/lib/services/heroku_beta.rb
@@ -93,7 +93,7 @@ class Service::HerokuBeta < Service::HttpPost
   end
 
   def heroku_build_output_url(id)
-    "https://dashboard-next.heroku.com/apps/#{heroku_application_name}/activity/builds/#{id}"
+    "https://dashboard.heroku.com/apps/#{heroku_application_name}/activity/builds/#{id}"
   end
 
   def heroku_app_access?

--- a/test/heroku_beta_test.rb
+++ b/test/heroku_beta_test.rb
@@ -50,7 +50,7 @@ class HerokuBetaTest < Service::TestCase
 
     heroku_build_id = SecureRandom.uuid
     heroku_build_path = "/apps/my-app/activity/builds/#{heroku_build_id}"
-    heroku_build_url  = "https://dashboard-next.heroku.com#{heroku_build_path}"
+    heroku_build_url  = "https://dashboard.heroku.com#{heroku_build_path}"
 
     @stubs.post "/apps/my-app/builds" do |env|
       assert_equal 'api.heroku.com', env[:url].host
@@ -94,7 +94,7 @@ class HerokuBetaTest < Service::TestCase
 
     heroku_build_id   = SecureRandom.uuid
     heroku_build_path = "/apps/my-app/activity/builds/#{heroku_build_id}"
-    heroku_build_url  = "https://dashboard-next.heroku.com#{heroku_build_path}"
+    heroku_build_url  = "https://dashboard.heroku.com#{heroku_build_path}"
 
     @stubs.post "/apps/my-app/builds" do |env|
       assert_equal 'api.heroku.com', env[:url].host


### PR DESCRIPTION
Revives this old PR https://github.com/github/github-services/pull/1056 to update the url for Heroku's dashboard.

