### PR TITLE
irc.rb: Properly handle getting repo owner in PRs

### DIFF
--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -138,11 +138,19 @@ class Service::IRC < Service
   end
 
   def irc_realname
-    repo_owner = payload["repository"]["owner"]["name"]
     repo_name = payload["repository"]["name"]
     repo_private = payload["repository"]["private"]
 
     "GitHub IRCBot - #{repo_owner}" + (repo_private == false ? "/#{repo_name}" : "")
+  end
+
+  def repo_owner
+    # for (what I presume to be) legacy reasonings, some events send owner login,
+    # others send owner name. this method accounts for both cases.
+    # sample: push event returns owner name, pull request event returns owner login
+    payload["repository"]["owner"]["name"] ?
+      payload["repository"]["owner"]["name"] :
+      payload["repository"]["owner"]["login"]
   end
 
   def debug_outgoing(command)

--- a/test/irc_test.rb
+++ b/test/irc_test.rb
@@ -122,7 +122,7 @@ class IRCTest < Service::TestCase
     svc.receive_push
     msgs = svc.writable_irc.string.split("\n")
     assert_equal "NICK n", msgs.shift
-    assert_match "USER n", msgs.shift
+    assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_match /PRIVMSG #r.*grit/, msgs.shift
@@ -139,7 +139,7 @@ class IRCTest < Service::TestCase
     svc.receive_push
     msgs = svc.writable_irc.string.split("\n")
     assert_equal "NICK n", msgs.shift
-    assert_match "USER n", msgs.shift
+    assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_match /PRIVMSG #r.*grit/, msgs.shift
@@ -156,7 +156,7 @@ class IRCTest < Service::TestCase
     svc.receive_push
     msgs = svc.writable_irc.string.split("\n")
     assert_equal "NICK n", msgs.shift
-    assert_match "USER n", msgs.shift
+    assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_match /PRIVMSG #r.*grit/, msgs.shift
@@ -173,7 +173,7 @@ class IRCTest < Service::TestCase
     svc.receive_commit_comment
     msgs = svc.writable_irc.string.split("\n")
     assert_equal "NICK n", msgs.shift
-    assert_match "USER n", msgs.shift
+    assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
@@ -187,7 +187,7 @@ class IRCTest < Service::TestCase
     svc.receive_pull_request
     msgs = svc.writable_irc.string.split("\n")
     assert_equal "NICK n", msgs.shift
-    assert_match "USER n", msgs.shift
+    assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
@@ -201,7 +201,7 @@ class IRCTest < Service::TestCase
     svc.receive_issues
     msgs = svc.writable_irc.string.split("\n")
     assert_equal "NICK n", msgs.shift
-    assert_match "USER n", msgs.shift
+    assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
@@ -215,7 +215,7 @@ class IRCTest < Service::TestCase
     svc.receive_issue_comment
     msgs = svc.writable_irc.string.split("\n")
     assert_equal "NICK n", msgs.shift
-    assert_match "USER n", msgs.shift
+    assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
@@ -229,7 +229,7 @@ class IRCTest < Service::TestCase
     svc.receive_pull_request_review_comment
     msgs = svc.writable_irc.string.split("\n")
     assert_equal "NICK n", msgs.shift
-    assert_match "USER n", msgs.shift
+    assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit.*pull request #5 /, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
@@ -243,7 +243,7 @@ class IRCTest < Service::TestCase
     svc.receive_gollum
     msgs = svc.writable_irc.string.split("\n")
     assert_equal "NICK n", msgs.shift
-    assert_match "USER n", msgs.shift
+    assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*\[grit\] defunkt created wiki page Foo/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip


### PR DESCRIPTION
Previously, it was assumed payload["repository"]["owner"]["name"] was
constant for all repositories. It was noticed that this is not the case,
and that the pull request event sends payload["repository"]["owner"]["login"]
instead.

A new method has been added to retrieve the repository owner, and
the tests have been amended to be more strict towards matching what
the realname may and may not contain.

fixes #1096, ref #1070 

---

Extra information:
https://developer.github.com/v3/activity/events/types/#pushevent
```json
  "repository": {
    "id": 35129377,
    "name": "public-repo",
    "full_name": "baxterthehacker/public-repo",
    "owner": {
      "name": "baxterthehacker",
```
https://developer.github.com/v3/activity/events/types/#pullrequestevent
```json
  "repository": {
    "id": 35129377,
    "name": "public-repo",
    "full_name": "baxterthehacker/public-repo",
    "owner": {
      "login": "baxterthehacker",
```

The Github employee I spoke with stated this might've been for historical reasons, and suggested I account for it in the code.

Lastly, the changes to the USER match in the tests might be confusing, so here is some extra explanation on how it works:

Normal USER string:
```
USER <username> <unused> <unused> :<real name/gecos>
USER nick * * :GitHub IRCBot - repo_owner/repo_name   # public repos
USER nick * * :GitHub IRCBot - repo_owner   # private repos
```

```regex
/USER n . . :[^-]+- \w+(\/\w+)?/
```

The regex will match both `repo_owner` and `repo_owner/repo_name`, but not `/repo_name` (and thus the test will fail when this happens.)