### PR TITLE
AmazonSNS service maximum message size

### DIFF
--- a/lib/services/amazon_sns.rb
+++ b/lib/services/amazon_sns.rb
@@ -26,60 +26,35 @@ class Service::AmazonSNS < Service
   # Maximum SNS message size is 256 kilobytes.
   MAX_MESSAGE_SIZE = 256 * 1024
 
-  # Size in bytes of each partial message.
+  # Size in bytes for each partial message.
   PARTIAL_MESSAGE_SIZE = 128 * 1024
 
   # Create a new SNS object using the AWS Ruby SDK and publish to it.
+  # If the message exceeds the maximum SNS size limit of 256K, then it will be
+  # sent in parts.
   # cfg - Configuration hash of key, secret, etc.
-  # json - THe valid JSON payload to send.
+  # json - The valid JSON payload to send.
   #
   # Returns the instantiated Amazon SNS Object
   def publish_to_sns(cfg, json)
-    begin
-      sns = Aws::SNS::Client.new({
-        :region            => cfg['sns_region'],
-        :access_key_id     => cfg['aws_key'],
-        :secret_access_key => cfg['aws_secret']
-      })
-
-      if json.bytesize <= MAX_MESSAGE_SIZE
-        sns.publish({
-          :message            => json,
-          :topic_arn          => cfg['sns_topic'],
-          :message_attributes => message_attributes
-        })
-      end
-
-      md5_digest = Digest::MD5.hexdigest(json)
-
-      payloads = split_bytes(json, PARTIAL_MESSAGE_SIZE)
-
-      messages = []
-      payloads.each_with_index do |payload, i|
-        messages << generate_json({
-          :error       => "Message exceeds the maximum SNS size limit of 256k",
-          :page_total  => payloads.length,
-          :page_number => i + 1,
-          :md5_digest  => md5_digest,
-          :message     => payload
-        })
-      end
-
-      messages.each do |message|
-        sns.publish({
-          :message            => message,
-          :topic_arn          => cfg['sns_topic'],
-          :message_attributes => message_attributes
-        })
-      end
-
-      rescue Aws::SNS::Errors::AuthorizationErrorException => e
-        raise_config_error e.message
-      rescue Aws::SNS::Errors::NotFoundException => e
-        raise_missing_error e.message
-      rescue SocketError
-        raise_missing_error
+    if json.bytesize <= MAX_MESSAGE_SIZE
+      return publish_messages_to_sns(cfg, [json])
     end
+
+    checksum = Digest::MD5.hexdigest(json)
+    payloads = split_bytes(json, PARTIAL_MESSAGE_SIZE)
+
+    messages = payloads.each_with_index.map do |payload, i|
+      generate_json({
+        :error       => "Message exceeds the maximum SNS size limit of 256K",
+        :page_total  => payloads.length,
+        :page_number => i + 1,
+        :checksum    => checksum,
+        :message     => payload
+      })
+    end
+
+    publish_messages_to_sns(cfg, messages)
   end
 
   # Build a valid AWS Configuration hash using the supplied
@@ -129,6 +104,40 @@ class Service::AmazonSNS < Service
   # Returns an array of strings.
   def split_bytes(string, n)
     string.bytes.each_slice(n).collect { |bytes| bytes.pack("C*") }
+  end
+
+  # Create a new SNS object using the AWS Ruby SDK and publish it.
+  # cfg - Configuration hash of key, secret, etc.
+  # messages - The valid JSON messages to send.
+  #
+  # Returns the instantiated Amazon SNS Object.
+  def publish_messages_to_sns(cfg, messages)
+    begin
+      sns = Aws::SNS::Client.new({
+        :region            => cfg['sns_region'],
+        :access_key_id     => cfg['aws_key'],
+        :secret_access_key => cfg['aws_secret']
+      })
+
+      messages.each_with_index do |message, i|
+        puts "message ##{i} is #{message.bytesize} bytes"
+        sns.publish({
+          :message            => message,
+          :topic_arn          => cfg['sns_topic'],
+          :message_attributes => message_attributes
+        })
+        puts "finished publishing message ##{i}"
+      end
+
+      sns
+
+    rescue Aws::SNS::Errors::AuthorizationErrorException => e
+      raise_config_error e.message
+    rescue Aws::SNS::Errors::NotFoundException => e
+      raise_missing_error e.message
+    rescue SocketError
+      raise_missing_error
+    end
   end
 
 end

--- a/lib/services/amazon_sns.rb
+++ b/lib/services/amazon_sns.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-core'
+require 'digest'
 
 class Service::AmazonSNS < Service
   self.title = "Amazon SNS"
@@ -22,6 +23,12 @@ class Service::AmazonSNS < Service
     publish_to_sns(data, generate_json(payload))
   end
 
+  # Maximum SNS message size is 256 kilobytes.
+  MAX_MESSAGE_SIZE = 256 * 1024
+
+  # Size in bytes of each partial message.
+  PARTIAL_MESSAGE_SIZE = 128 * 1024
+
   # Create a new SNS object using the AWS Ruby SDK and publish to it.
   # cfg - Configuration hash of key, secret, etc.
   # json - THe valid JSON payload to send.
@@ -35,17 +42,43 @@ class Service::AmazonSNS < Service
         :secret_access_key => cfg['aws_secret']
       })
 
-      sns.publish({
-        :message            => json,
-        :topic_arn          => cfg['sns_topic'],
-        :message_attributes => message_attributes
-      })
-    rescue Aws::SNS::Errors::AuthorizationErrorException => e
-      raise_config_error e.message
-    rescue Aws::SNS::Errors::NotFoundException => e
-      raise_missing_error e.message
-    rescue SocketError
-      raise_missing_error
+      if json.bytesize <= MAX_MESSAGE_SIZE
+        sns.publish({
+          :message            => json,
+          :topic_arn          => cfg['sns_topic'],
+          :message_attributes => message_attributes
+        })
+      end
+
+      md5_digest = Digest::MD5.hexdigest(json)
+
+      payloads = split_bytes(json, PARTIAL_MESSAGE_SIZE)
+
+      messages = []
+      payloads.each_with_index do |payload, i|
+        messages << generate_json({
+          :error       => "Message exceeds the maximum SNS size limit of 256k",
+          :page_total  => payloads.length,
+          :page_number => i + 1,
+          :md5_digest  => md5_digest,
+          :message     => payload
+        })
+      end
+
+      messages.each do |message|
+        sns.publish({
+          :message            => message,
+          :topic_arn          => cfg['sns_topic'],
+          :message_attributes => message_attributes
+        })
+      end
+
+      rescue Aws::SNS::Errors::AuthorizationErrorException => e
+        raise_config_error e.message
+      rescue Aws::SNS::Errors::NotFoundException => e
+        raise_missing_error e.message
+      rescue SocketError
+        raise_missing_error
     end
   end
 
@@ -87,6 +120,15 @@ class Service::AmazonSNS < Service
     end
 
     data['sns_region'] = "us-east-1" if data['sns_region'].to_s.empty?
+  end
+
+  private
+
+  # Split the string into chunks of n bytes.
+  #
+  # Returns an array of strings.
+  def split_bytes(string, n)
+    string.bytes.each_slice(n).collect { |bytes| bytes.pack("C*") }
   end
 
 end

--- a/test/amazon_sns_test.rb
+++ b/test/amazon_sns_test.rb
@@ -9,7 +9,10 @@ end
 
 class AmazonSNSTest < Service::TestCase
 
-  #Use completely locked down IAM resource.
+  # SNS maximum message size is 256 kilobytes.
+  SNS_MAX_MESSAGE_SIZE = 256 * 1024
+
+  # Use completely locked down IAM resource.
   def data
     {
       'aws_key' => 'AKIAJV3OTFPCKNH53IBQ',
@@ -19,9 +22,15 @@ class AmazonSNSTest < Service::TestCase
     }
   end
 
-  def payload 
+  def payload
     {
       "test" => "true"
+    }
+  end
+
+  def large_payload
+    {
+      "test" => 0.to_s * (SNS_MAX_MESSAGE_SIZE + 1)
     }
   end
 
@@ -37,6 +46,12 @@ class AmazonSNSTest < Service::TestCase
 
   def verify_requires(svc)
     assert_raises Service::ConfigurationError do
+      svc.receive_event
+    end
+  end
+
+  def verify_nothing_raised(svc)
+    assert_nothing_raised do
       svc.receive_event
     end
   end
@@ -62,6 +77,14 @@ class AmazonSNSTest < Service::TestCase
     svc.validate_data
 
     assert_equal svc.data['sns_region'], data['sns_region']
+  end
+
+  def test_publish_to_sns
+    verify_nothing_raised(service :push, data, payload)
+  end
+
+  def test_payload_exceeds_256K
+    verify_nothing_raised(service :push, data, large_payload)
   end
 
   def service(*args)

--- a/test/amazon_sns_test.rb
+++ b/test/amazon_sns_test.rb
@@ -80,10 +80,12 @@ class AmazonSNSTest < Service::TestCase
   end
 
   def test_publish_to_sns
+    skip 'aws_key is outdated, and this test will fail. Consider updating/refactoring out aws credentials to re-enable this test'
     verify_nothing_raised(service :push, data, payload)
   end
 
   def test_payload_exceeds_256K
+    skip 'aws_key is outdated, and this test will fail. Consider updating/refactoring out aws credentials to re-enable this test'
     verify_nothing_raised(service :push, data, large_payload)
   end
 


### PR DESCRIPTION
# Purpose

[`Service::AmazonSNS#publish_to_sns`](https://github.com/hudl/github-services/blob/54c1d7ff78b55bea788c7c0ddc4d60e5f457f295/lib/services/amazon_sns.rb#L37) now checks for the maximum message size of 256K. If the message exceeds the maximum size, it will split the payload into parts with some ordering information and an md5 digest of the original payload.

Resolves #1091