### PR TITLE
Specifying the HipChat token must be a V1 token

### DIFF
--- a/docs/hipchat
+++ b/docs/hipchat
@@ -10,7 +10,7 @@ descriptions can be found here: http://developer.github.com/v3/repos/hooks/
 Install Notes
 -------------
 
-1. **Auth Token** - One of your group's API tokens. See: http://www.hipchat.com/docs/api/auth
+1. **Auth Token** - One of your group's V1 API tokens. See: http://www.hipchat.com/docs/api/auth
 2. **Room** - The full name of the room to send the message to. The room's room_id will also work.
 3. **Restrict to Branch** - List of branches to which will be inspected.
 4. **Color** - Optional background color for the message. Available options are: yellow, red, green, purple, gray, or random. Defaults to yellow.


### PR DESCRIPTION
It is not immediately obvious looking at the URL listed that you need to use a V1 token from HipChat. They offer both V1 and V2 tokens, V1 being deprecated, but GitHub only supports V1 tokens.