### PR TITLE
fix used path when using multi-token support for OBS triggers

### DIFF
--- a/lib/services/obs.rb
+++ b/lib/services/obs.rb
@@ -17,8 +17,9 @@ class Service::Obs < Service::HttpPost
   def receive_push
     # required
     token = required_config_value('token').to_s
-    url = config_value('url')
-    url = "https://api.opensuse.org:443" if url.blank?
+    base_url = config_value('url')
+    base_url = "https://api.opensuse.org:443" if base_url.blank?
+    base_url << "/trigger/runservice"
 
     # optional. The token may set the package container already.
     project = config_value('project')
@@ -43,7 +44,7 @@ class Service::Obs < Service::HttpPost
       http.ssl[:verify] = false
       http.headers['Authorization'] = "Token #{t.strip}"
 
-      url = "#{url}/trigger/runservice"
+      url = base_url.clone
       unless project.blank? or package.blank?
         url << "?project=#{CGI.escape(project)}&package=#{CGI.escape(package)}"
       end


### PR DESCRIPTION
The old code works in test suite, but not on production. we receive repeating "/trigger/runservice"
elements (eg. "/trigger/runservice/trigger/runservice") atm