### PR TITLE
Ensure asana payload is www-form encoded

### DIFF
--- a/lib/services/asana.rb
+++ b/lib/services/asana.rb
@@ -52,7 +52,7 @@ class Service::Asana < Service
     http.basic_auth(data['auth_token'], "")
     http.headers['X-GitHub-Event'] = event.to_s
 
-    res = http_post "https://app.asana.com/api/1.0/tasks/#{task_id}/stories", "text=#{text}"
+    res = http_post "https://app.asana.com/api/1.0/tasks/#{task_id}/stories", URI.encode_www_form("text" => text)
     case res.status
     when 200..299
       # Success

--- a/test/asana_test.rb
+++ b/test/asana_test.rb
@@ -5,18 +5,24 @@ class AsanaTest < Service::TestCase
     @stubs = Faraday::Adapter::Test::Stubs.new
   end
 
+  def decode_body(body)
+    Hash[URI.decode_www_form(body)]
+  end
+
   def test_push
 
     @stubs.post "/api/1.0/tasks/1234/stories" do |env|
-      assert_match /rtomayko pushed to branch master of mojombo\/grit/, env[:body]
-      assert_match /#1234/, env[:body]
+      body = decode_body(env[:body])
+      assert_match /rtomayko pushed to branch master of mojombo\/grit/, body["text"]
+      assert_match /#1234/, body["text"]
       assert_match /Basic MDAwMDo=/, env[:request_headers][:authorization]
       [200, {}, '']
     end
 
     @stubs.post "/api/1.0/tasks/1235/stories" do |env|
-      assert_match /rtomayko pushed to branch master of mojombo\/grit/, env[:body]
-      assert_match /#1235/, env[:body]
+      body = decode_body(env[:body])
+      assert_match /rtomayko pushed to branch master of mojombo\/grit/, body["text"]
+      assert_match /#1235/, body["text"]
       assert_match /Basic MDAwMDo=/, env[:request_headers][:authorization]
       [200, {}, '']
     end
@@ -30,19 +36,21 @@ class AsanaTest < Service::TestCase
   def test_restricted_comment_commit_push
 
     @stubs.post "/api/1.0/tasks/1234/stories" do |env|
-      assert_match /rtomayko pushed to branch master of mojombo\/grit/, env[:body]
-      refute_match /stub git call for Grit#heads test f:15 Case#1234/, env[:body]
-      assert_match /add more comments about #1235 and #1234 throughout/, env[:body]
-      assert_match /#1234/, env[:body]
+      body = decode_body(env[:body])
+      assert_match /rtomayko pushed to branch master of mojombo\/grit/, body["text"]
+      refute_match /stub git call for Grit#heads test f:15 Case#1234/, body["text"]
+      assert_match /add more comments about #1235 and #1234 throughout/, body["text"]
+      assert_match /#1234/, body["text"]
       assert_match /Basic MDAwMDo=/, env[:request_headers][:authorization]
       [200, {}, '']
     end
 
     @stubs.post "/api/1.0/tasks/1235/stories" do |env|
-      assert_match /rtomayko pushed to branch master of mojombo\/grit/, env[:body]
-      refute_match /#1234 clean up heads test f:2hrs #1235/, env[:body]
-      assert_match /add more comments about #1235 and #1234 throughout/, env[:body]
-      assert_match /#1235/, env[:body]
+      body = decode_body(env[:body])
+      assert_match /rtomayko pushed to branch master of mojombo\/grit/, body["text"]
+      refute_match /#1234 clean up heads test f:2hrs #1235/, body["text"]
+      assert_match /add more comments about #1235 and #1234 throughout/, body["text"]
+      assert_match /#1235/, body["text"]
       assert_match /Basic MDAwMDo=/, env[:request_headers][:authorization]
       [200, {}, '']
     end
@@ -56,12 +64,14 @@ class AsanaTest < Service::TestCase
   def test_restricted_branch_commit_push
 
     @stubs.post "/api/1.0/tasks/1234/stories" do |env|
-      refute_match /stub git call for Grit#heads test f:15 Case#1234/, env[:body]
+      body = decode_body(env[:body])
+      refute_match /stub git call for Grit#heads test f:15 Case#1234/, body["text"]
       [200, {}, '']
     end
 
     @stubs.post "/api/1.0/tasks/1235/stories" do |env|
-      refute_match /#1234 clean up heads test f:2hrs #1235/, env[:body]
+      body = decode_body(env[:body])
+      refute_match /#1234 clean up heads test f:2hrs #1235/, body["text"]
       [200, {}, '']
     end
 
@@ -77,7 +87,8 @@ class AsanaTest < Service::TestCase
     end
 
     @stubs.post "/api/1.0/tasks/1234/stories" do |env|
-      assert_match /#1234/, env[:body]
+      body = decode_body(env[:body])
+      assert_match /#1234/, body["text"]
       [200, {}, '']
     end
 


### PR DESCRIPTION
This fixes the issue where the '&' symbol would be taken as a separator
of the payload rather than payload data. Asana decodes the payload and
displays it without truncating after the '&'.

Fixes #1107 
