### PR TITLE
@#123

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    github-services (1.0.0.ad54999)
+    github-services (1.0.0.e38ed97)
       activeresource (~> 4.0.0)
       addressable (~> 2.3)
       aws-sdk (~> 1.27)
@@ -133,3 +133,6 @@ DEPENDENCIES
   github-services!
   minitest
   rake (= 10.0.3)
+
+BUNDLED WITH
+   1.10.6

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,5 +3,10 @@
 # Ensures all gems are in vendor/cache and installed locally.
 set -e
 
+if [ "$(uname -s)" = "Darwin" ]; then
+  HOMEBREW_PREFIX="$(brew --prefix)"
+  bundle config --local build.eventmachine "--with-cppflags=-I$HOMEBREW_PREFIX/opt/openssl/include"
+fi
+
 bundle install --binstubs --local --path=vendor/gems
 bundle package --all


### PR DESCRIPTION
)To display a richly-formatted message attachment in Slack, you can use the same JSON payload as above, but add in an attachments array. Each element of this array is a hash containing the following parameters: 
