### PR TITLE
Add an X-Github-Event header to DeployHQ service.

### DIFF
--- a/lib/services/deploy_hq.rb
+++ b/lib/services/deploy_hq.rb
@@ -15,6 +15,8 @@ class Service::DeployHq < Service
 
     http.url_prefix = data['deploy_hook_url']
     http.headers['content-type'] = 'application/x-www-form-urlencoded'
+    http.headers['X-Github-Event'] = 'push'
+
     body = Faraday::Utils.build_nested_query(http.params.merge(:payload => generate_json(payload), :notify => email_pusher))
 
     http_post data['deploy_hook_url'], body


### PR DESCRIPTION
To make DeployHQ more compatible with Github webooks (now the reccomended way of integrating), Deploy now expects an X-Github-Event push header to be present.