### PR TITLE
twitter: use different character for asterisks.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    github-services (1.0.0.76234e0)
+    github-services (1.0.0.8dc2328)
       activeresource (~> 4.0.0)
       addressable (~> 2.3)
       aws-sdk (~> 1.27)

--- a/lib/services/twitter.rb
+++ b/lib/services/twitter.rb
@@ -41,7 +41,6 @@ class Service::Twitter < Service
         author = commit['author'] || {}
         url = commit['url']
         message = commit['message']
-        message.gsub!("*", "%2A")
         # Strip out leading @s so that github @ mentions don't become twitter @ mentions
         # since there's zero reason to believe IDs on one side match IDs on the other
         message.gsub!(/\B[@＠][[:word:]]/) do |word|
@@ -52,6 +51,8 @@ class Service::Twitter < Service
         else
           "[#{repository}] #{url} #{author['name']} - #{message}"
         end
+        # Twitter barfs on asterisks so replace them with a slightly different unicode one.
+        status.gsub!("*", "﹡")
         # The URL is going to be shortened by twitter. It's length will be at most 23 chars (HTTPS).
         length = status.length - url.length + TWITTER_SHORT_URL_LENGTH_HTTPS
         # How many chars of the status can we actually use?

--- a/test/twitter_test.rb
+++ b/test/twitter_test.rb
@@ -70,8 +70,8 @@ class TwitterTest < Service::TestCase
     assert_match p['commits'][0]['message'], svc.statuses[0]
   end
 
-  # Make sure that asterisks in the original commit message are escaped
-  def test_asterisk_escaped
+  # Make sure that asterisks in the original commit message are replaced
+  def test_asterisk_replace
     p = payload
     p['commits'][0]['message']="message * with * stars"
     svc = service({'token' => 't', 'secret' => 's'}, p)
@@ -85,7 +85,7 @@ class TwitterTest < Service::TestCase
     end
 
     svc.receive_push
-    assert_match "message %2A with %2A stars", svc.statuses[0]
+    assert_match "message ﹡ with ﹡ stars", svc.statuses[0]
   end
 
   # Make sure that GitHub @mentions are injected with a zero-width space


### PR DESCRIPTION
This should get around the failed escaping attempt previously and allow this character to be used in statuses.

CC @kdaigle @izuzak @aoaaxy 