### PR TITLE
Fix the capitalization of GitHub in DeployHQ

### DIFF
--- a/lib/services/deploy_hq.rb
+++ b/lib/services/deploy_hq.rb
@@ -15,7 +15,7 @@ class Service::DeployHq < Service
 
     http.url_prefix = data['deploy_hook_url']
     http.headers['content-type'] = 'application/x-www-form-urlencoded'
-    http.headers['X-Github-Event'] = 'push'
+    http.headers['X-GitHub-Event'] = 'push'
 
     body = Faraday::Utils.build_nested_query(http.params.merge(:payload => generate_json(payload), :notify => email_pusher))
 


### PR DESCRIPTION
@darkphnx "good" HTTP libraries shouldn't care about the capitalization of headers but for the sake of our human readers @gjtorikian makes a good point that it should continue to be consistent. :sparkles: