### PR TITLE
Make token optional

### DIFF
--- a/lib/services/packagist.rb
+++ b/lib/services/packagist.rb
@@ -21,7 +21,11 @@ class Service::Packagist < Service
   end
 
   def token
-    data['token'].strip
+    if data['token'].to_s == ''
+      ''
+    else
+      data['token'].strip
+    end
   end
 
   def scheme

--- a/test/packagist_test.rb
+++ b/test/packagist_test.rb
@@ -54,13 +54,13 @@ class PackagistTest < Service::TestCase
   def test_handles_blank_strings_without_errors
     data = {
       'user' => '',
-      'token' => '5gieo7lwcd8gww800scs',
+      'token' => '',
       'domain' => ''
     }
 
     svc = service(data, payload)
     assert_equal 'mojombo', svc.user
-    assert_equal '5gieo7lwcd8gww800scs', svc.token
+    assert_equal '', svc.token
     assert_equal 'packagist.org', svc.domain
     assert_equal 'https', svc.scheme
   end


### PR DESCRIPTION
The token is actually optional depending on which domain you send to, fixing this as per a support thread between Hussam Hebbo & Ivan Žužak (GH).
