### PR TITLE
Silences failing test

### DIFF
--- a/test/mqtt_test.rb
+++ b/test/mqtt_test.rb
@@ -6,6 +6,7 @@ class MqttPubTest < Service::TestCase
   end
 
   def test_push
+    skip "Temporarily disabled as the q.m2m.io host is returning 503 errors"
     svc = service :push, {'broker' => 'q.m2m.io','port' => '1883', 'id' => 'github', 'topic' => 'github/franklovecchio/github-services'}, 'payload'
     svc.receive
   end


### PR DESCRIPTION
Resolves #1138.

This pull request offers a temporary solution to skip the failing MQTT test as we continue to investigate an alternative to the `q.m2m.io` host.