### PR TITLE
Loosen aws-sdk requirement

### DIFF
--- a/github-services.gemspec
+++ b/github-services.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "softlayer_messaging", "~> 1.0.2"
 
   # Amazon SQS, AWS OpsWorks
-  spec.add_dependency "aws-sdk", "~> 1.50"
+  spec.add_dependency "aws-sdk", "~> 1.66"
 
   # AWS CodeDeploy, Amazon SNS
   spec.add_dependency "aws-sdk-core", "~>2.0.8"

--- a/github-services.gemspec
+++ b/github-services.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "softlayer_messaging", "~> 1.0.2"
 
   # Amazon SQS, AWS OpsWorks
-  spec.add_dependency "aws-sdk", "~> 1.66"
+  spec.add_dependency "aws-sdk", "~> 1.64"
 
   # AWS CodeDeploy, Amazon SNS
   spec.add_dependency "aws-sdk-core", "~>2.0.8"

--- a/github-services.gemspec
+++ b/github-services.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "softlayer_messaging", "~> 1.0.2"
 
   # Amazon SQS, AWS OpsWorks
-  spec.add_dependency "aws-sdk", "~> 1.50.0"
+  spec.add_dependency "aws-sdk", "~> 1.50"
 
   # AWS CodeDeploy, Amazon SNS
   spec.add_dependency "aws-sdk-core", "~>2.0.8"


### PR DESCRIPTION
In #1136, the `aws-sdk` dependency was bumped to version `1.50.0` to add support for passing message attributes in SQS payloads. The internal system that GitHub uses this gem for has `aws-sdk` locked at `1.64.0`, which is causing conflicts. 

This pull request loosens the version requirements of the `aws-sdk`. By specifying the dependency version as `1.64`, we're saying "please find a suitable version (higher than `1.64`) that matches `1.x.x`", as opposed to `1.50.x`. 

The only significance of `1.64` over `1.50` is to match the version already locked in our internal system.

/cc @jwhitcraft 