### PR TITLE
Add strap support

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,8 @@
+# Helpers
+tap "github/bootstrap"
+
+# Ruby
+brew "openssl"
+brew "autoconf"
+brew "rbenv"
+brew "ruby-build"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,10 +3,17 @@
 # Ensures all gems are in vendor/cache and installed locally.
 set -e
 
+# github/strap related bootstrapping
 if [ "$(uname -s)" = "Darwin" ]; then
-  HOMEBREW_PREFIX="$(brew --prefix)"
-  bundle config --local build.eventmachine "--with-cppflags=-I$HOMEBREW_PREFIX/opt/openssl/include"
+  brew update >/dev/null
+  brew bundle check &>/dev/null || brew bundle
+
+  brew bootstrap-rbenv-ruby
+
+  BUNDLE="brew bundle exec -- bundle"
+else
+  BUNDLE="bundle"
 fi
 
-bundle install --binstubs --local --path=vendor/gems
+$BUNDLE install --binstubs --local --path=vendor/gems
 bundle package --all


### PR DESCRIPTION
This adds support for bootstrapping in development using strap, as a part of sunsetting support for Boxen. (see github/workflow-tools#151)

cc @bhuga, @mikemcquaid