### PR TITLE
auto_deploy: remove / from end of github_api_url.

### DIFF
--- a/lib/services/auto_deploy.rb
+++ b/lib/services/auto_deploy.rb
@@ -135,7 +135,7 @@ class Service::AutoDeploy < Service::HttpPost
     if config_value("github_api_url").empty?
       "https://api.github.com"
     else
-      config_value("github_api_url")
+      config_value("github_api_url").chomp("/")
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/github/internal-developer.github.com/pull/943.

CC @gjtorikian and @jonico for thoughts.