### PR TITLE
Fix contributing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ GitHub Services
 
 This repository contains code to integrate GitHub.com with third party services.
 
-See the [Contributing Guidelines](https://github.com/github/github-services/blob/master/CONTRIBUTING.md) for instructions on contributing a service.
+See the [Contributing Guidelines](https://github.com/github/github-services/blob/master/.github/CONTRIBUTING.md) for instructions on contributing a service.
 
 Current Status
 ==============


### PR DESCRIPTION
Fixes `CONTRIBUTING.md` link, since it has now moved under the `.github` folder.

