### PR TITLE
Add the new header for GoCD service API

### DIFF
--- a/lib/services/gocd.rb
+++ b/lib/services/gocd.rb
@@ -14,6 +14,7 @@ class Service::GoCD < Service
 
     http.ssl[:verify] = verify_ssl
     http.url_prefix = base_url
+    http.headers['confirm'] = true
 
     http.basic_auth username, password if username.present? and password.present?
 


### PR DESCRIPTION
In the latest GoCD release, a new HTTP header is added in its material notification API: https://api.go.cd/current/#notify-git-materials. As a result, the current GoCD github-services is broken. Adding `http.headers['confirm'] = true` will fix this. (I have tested it in my GitHub Enterprise instance)

(This patch also converts line-endings to Unix-style)