### PR TITLE
irc: no longer expose NickServ password in security settings

### DIFF
--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -1,6 +1,6 @@
 class Service::IRC < Service
-  string   :server, :port, :room, :nick, :branches, :nickserv_password
-  password :password
+  string   :server, :port, :room, :nick, :branches
+  password :password, :nickserv_password
   boolean  :ssl, :message_without_join, :no_colors, :long_url, :notice
   white_list :server, :port, :room, :nick
 


### PR DESCRIPTION
IRC Passwords were being exposed in security settings of your account. Hopefully this fixes it. (I have only ran tests and can't do much more than that, but the change seems straightforward)

Previous behaviour exposes the password in https://github.com/settings/security/
