### PR TITLE
remove `magnum` from travis-ci.com link

### DIFF
--- a/docs/travis
+++ b/docs/travis
@@ -6,7 +6,7 @@ For more details about Travis, go to http://docs.travis-ci.com.
 
 ## Automatic configuration from Travis CI
 We recommend using the Travis profile page at https://travis-ci.org/profile to manage your hooks.
-For private repositories, use https://magnum.travis-ci.com/profile.
+For private repositories, use https://travis-ci.com/profile.
 
 ## Travis CI Status
 Travis CI status page: http://status.travis-ci.com


### PR DESCRIPTION
We're no longer using `magnum.travis-ci.com`. It redirects do `travis-ci.com` anyway and the magnum might just confuse people.