### PR TITLE
Allow pushbullet API keys to contain periods

### DIFF
--- a/lib/services/pushbullet.rb
+++ b/lib/services/pushbullet.rb
@@ -14,7 +14,7 @@ class Service::Pushbullet < Service::HttpPost
     :email => 'hey@pushbullet.com'
 
   def receive_event
-    unless required_config_value('api_key').match(/^[A-Za-z0-9]+$/)
+    unless required_config_value('api_key').match(/^[A-Za-z0-9\.]+$/)
       raise_config_error "Invalid api key."
     end
     unless config_value('device_iden').match(/^([A-Za-z0-9]+|)$/)


### PR DESCRIPTION
I've tested this endpoint and it still works, API keys can now just contain periods on pushbullets side.