### PR TITLE
Configurable endpoint region

### DIFF
--- a/docs/awsopsworks
+++ b/docs/awsopsworks
@@ -27,5 +27,6 @@ Install Notes
 3. **Branch Name** (required) - "Branch/Revision" configured for that app in the AWS OpsWorks Console or see `Revision` at http://docs.aws.amazon.com/opsworks/latest/APIReference/API_Source.html
 4. **Aws Access Key Id** (required) - Access key id of an AWS IAM user having the permission for the `opsworks:CreateDeployment` action.
 5. **Aws Secret Access Key** (required) - Corresponding secret access key of the AWS IAM user.
+6. **Endpoint Region** (Optional) - The API endpoint region for your stack. Defaults to us-east-1 (classic)
 6. **GitHub Token** (Optional) - A GitHub personal access token with `repo` scope to for OAuth cloning and deployment statuses for the GitHub API.
 7. **GitHub API Url** (Optional) - The URL for the GitHub API. Override this for enterprise. e.g. `https://enterprise.myorg.com`.

--- a/lib/services/aws_ops_works.rb
+++ b/lib/services/aws_ops_works.rb
@@ -6,6 +6,7 @@ class Service::AwsOpsWorks < Service::HttpPost
   string     :app_id,               # see AppId at http://docs.aws.amazon.com/opsworks/latest/APIReference/API_App.html
              :stack_id,             # see StackId at http://docs.aws.amazon.com/opsworks/latest/APIReference/API_Stack.html
              :branch_name,          # see Revision at http://docs.aws.amazon.com/opsworks/latest/APIReference/API_Source.html
+             :endpoint_region,      # see AWS Opsworks Stacks at http://docs.aws.amazon.com/general/latest/gr/rande.html#opsworks_region
              :github_api_url,       # The GitHub API endpoint to post DeploymentStatus callbacks to
              :aws_access_key_id     # see AWSAccessKeyID at http://docs.aws.amazon.com/opsworks/latest/APIReference/CommonParameters.html
   password   :aws_secret_access_key, :github_token
@@ -13,6 +14,7 @@ class Service::AwsOpsWorks < Service::HttpPost
   white_list :app_id,
              :stack_id,
              :branch_name,
+             :endpoint_region,
              :github_api_url,
              :aws_access_key_id
 
@@ -140,7 +142,8 @@ class Service::AwsOpsWorks < Service::HttpPost
 
   def ops_works_client
     AWS::OpsWorks::Client.new access_key_id:     required_config_value('aws_access_key_id'),
-                              secret_access_key: required_config_value('aws_secret_access_key')
+                              secret_access_key: required_config_value('aws_secret_access_key'),
+                              region:            config_value('endpoint_region')
   end
 
   def github_api_url


### PR DESCRIPTION
OpsWorks has implemented region specific API endpoints. This service is hardcoded to `us-east-1`, which won't connect to a stack if it uses a region specific API endpoint. 

This PR just adds an optional config to set the endpoint region. Leaving it blank will default to `us-east-1` as it did previously.