### PR TITLE
Asana Integration Restrict to Last Commit Issue

### DIFF
--- a/lib/services/asana.rb
+++ b/lib/services/asana.rb
@@ -2,7 +2,7 @@ class Service::Asana < Service
   password :auth_token
   string :restrict_to_branch
   boolean :restrict_to_last_commit
-  white_list :restrict_to_branch, :restrict_to_last_comment
+  white_list :restrict_to_branch, :restrict_to_last_commit
 
   def receive_push
     # make sure we have what we need
@@ -12,7 +12,7 @@ class Service::Asana < Service
     branch = payload['ref'].split('/').last
 
     branch_restriction = data['restrict_to_branch'].to_s
-    commit_restriction = config_boolean_true?('restrict_to_last_comment')
+    commit_restriction = config_boolean_true?('restrict_to_last_commit')
 
     # check the branch restriction is poplulated and branch is not included
     if branch_restriction.length > 0 && branch_restriction.index(branch) == nil

--- a/test/asana_test.rb
+++ b/test/asana_test.rb
@@ -56,7 +56,7 @@ class AsanaTest < Service::TestCase
     end
 
     svc = service(
-      {'auth_token' => '0000',"restrict_to_last_comment" => "1"},
+      {'auth_token' => '0000',"restrict_to_last_commit" => "1"},
       modified_payload)
     svc.receive_push
   end


### PR DESCRIPTION
Seems that the `Restrict to last commit` functionality does not work as instead of checking the `restrict_to_last_commit` the code was checking the `restrict_to_last_comment`.