### PR TITLE
Fixes for TeamCity 2017.1

### DIFF
--- a/docs/teamcity
+++ b/docs/teamcity
@@ -1,7 +1,7 @@
 [TeamCity](https://www.jetbrains.com/teamcity/) is a continuous integration server that automates building and testing of your software.
 
 <aside class="notice">
-Note that since TeamCity 10.0 using the [TeamCity Commit Hooks] (https://plugins.jetbrains.com/plugin/9179?pr=teamcity) plugin is recommended. 
+Note that since TeamCity 10.0 using the [TeamCity Commit Hooks](https://plugins.jetbrains.com/plugin/9179?pr=teamcity) plugin is recommended. 
 </aside>
 The GitHub TeamCity service can be used in two ways:
 * to trigger builds after code has been pushed to your git repository; (Default)

--- a/lib/services/teamcity.rb
+++ b/lib/services/teamcity.rb
@@ -36,9 +36,9 @@ class Service::TeamCity < Service
 
       if check_for_changes_only
         # This is undocumented call. TODO: migrate to REST API (TC at least 8.0)
-        res = http_get "httpAuth/action.html", :checkForChangesBuildType => build_type_id
+        res = http_post "httpAuth/action.html", :checkForChangesBuildType => build_type_id
       else
-        res = http_get "httpAuth/action.html", :add2Queue => build_type_id, :branchName => branch
+        res = http_post "httpAuth/action.html", :add2Queue => build_type_id, :branchName => branch
       end
 
       case res.status

--- a/test/teamcity_test.rb
+++ b/test/teamcity_test.rb
@@ -7,7 +7,7 @@ class TeamCityTest < Service::TestCase
 
   def test_push
     url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
+    @stubs.post url do |env|
       assert_equal 'teamcity.com', env[:url].host
       assert_equal 'btid', env[:params]['add2Queue']
       assert_equal basic_auth(:u, :p), env[:request_headers]['authorization']
@@ -26,7 +26,7 @@ class TeamCityTest < Service::TestCase
 
   def test_push_deleted_branch
     url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
+    @stubs.post url do |env|
       assert false, "service should not be called for deleted branches"
     end
 
@@ -42,7 +42,7 @@ class TeamCityTest < Service::TestCase
 
   def test_push_with_branch_name
     url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
+    @stubs.post url do |env|
       assert_equal 'branch-name', env[:params]['branchName']
       [200, {}, '']
     end
@@ -58,7 +58,7 @@ class TeamCityTest < Service::TestCase
 
   def test_push_with_branch_name_incl_slashes
     url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
+    @stubs.post url do |env|
       assert_equal 'branch/name', env[:params]['branchName']
       [200, {}, '']
     end
@@ -74,7 +74,7 @@ class TeamCityTest < Service::TestCase
 
   def test_push_with_branch_full_ref
     url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
+    @stubs.post url do |env|
       assert_equal 'refs/heads/branch/name', env[:params]['branchName']
       [200, {}, '']
     end
@@ -91,7 +91,7 @@ class TeamCityTest < Service::TestCase
 
   def test_push_when_check_for_changes_is_true
     url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
+    @stubs.post url do |env|
       assert_equal 'teamcity.com', env[:url].host
       assert_equal 'btid', env[:params]['checkForChangesBuildType']
       [200, {}, '']


### PR DESCRIPTION
TeamCity 2017.1 was recently released, and it (finally) doesn't allow you to start a build by issuing a GET request.  ([Source](https://confluence.jetbrains.com/display/TCD10/Upgrade+Notes))

> if you use non-bundled clients which perform HTTP GET requests to TeamCity, some of the GET requests (those which change the state of the server, like http://server/action.html?add2Queue=XXX) stop working in 2017.1, please change the requests to use POST instead of GET;

If this could get merged and deployed it would really help us, we have dozens of projects that use this service that now don't build automatically...