### PR TITLE
Ensure default region is used when none specified

### DIFF
--- a/lib/services/aws_ops_works.rb
+++ b/lib/services/aws_ops_works.rb
@@ -141,9 +141,13 @@ class Service::AwsOpsWorks < Service::HttpPost
   end
 
   def ops_works_client
+    region = config_value('endpoint_region')
+    # The AWS library requires you pass `nil`, and not an empty string, if you
+    # want to connect to a legitimate default AWS host name.
+    region = nil if region.empty?
     AWS::OpsWorks::Client.new access_key_id:     required_config_value('aws_access_key_id'),
                               secret_access_key: required_config_value('aws_secret_access_key'),
-                              region:            config_value('endpoint_region')
+                              region:            region
   end
 
   def github_api_url

--- a/test/aws_ops_works_test.rb
+++ b/test/aws_ops_works_test.rb
@@ -52,6 +52,11 @@ class AwsOpsWorksTest < Service::TestCase
     assert_equal sample_data['aws_access_key_id'], config.access_key_id
   end
 
+  def test_region_configured
+    config = service.ops_works_client.config
+    assert_equal sample_data['region'], config.ops_works_region
+  end
+
   def test_aws_access_key_id_missing
     svc = service(sample_data.except('aws_access_key_id'))
     assert_raises Service::ConfigurationError do
@@ -71,6 +76,12 @@ class AwsOpsWorksTest < Service::TestCase
     end
   end
 
+  def test_region_blank
+    svc = service(sample_data.merge('region' => ""))
+    config = service.ops_works_client.config
+    assert_equal sample_data['region'], config.ops_works_region
+  end
+
   def service(data = sample_data, payload = sample_payload)
     Service::AwsOpsWorks.new(:push, data, payload)
   end
@@ -81,6 +92,7 @@ class AwsOpsWorksTest < Service::TestCase
       'aws_secret_access_key' => '0123456789+0123456789+0123456789+0123456',
       'stack_id'              => '12345678-1234-1234-1234-123456789012',
       'app_id'                => '01234567-0123-0123-0123-012345678901',
+      'region'                => "us-east-1",
       'branch_name'           => 'default-branch'
     }
   end


### PR DESCRIPTION
The prior behavior caused `region` to be set to `""` when no region was
configured. This ended up causing the AWS `ops_works_region` to be set to `""`.
And, this ended up causing the `ops_works_endpoint` to be set to
`opsworks..amazonaws.com` (notice the double dots) instead of something like `opsworks.us-
east-1.amazonaws.com`. This eventually lead to an SSL error since the certificate served didn't match up with a host of `opsworks..amazonaws.com` (to say nothing of why Ruby allowed resolving such a hostname to begin with). So, we work around this by ensuring `nil` is passed in
when no region is specified.

Please note: GitHub will only accept pull requests to existing services that implement bug fixes or security improvements. We no longer accept feature changes to existing services.