### PR TITLE
Fixed broken link to "Integrations Directory"

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this.
 
 **NOTE**: GitHub no longer accepts new services. If you'd like to integrate
-your application or service with GitHub, you should use [webhooks][webhooks] which will `POST` a payload to your server for each event or request to join the [GitHub Integrations Directory](https://github.com/integrations).
+your application or service with GitHub, you should use [webhooks][webhooks] which will `POST` a payload to your server for each event or request to join the [GitHub Marketplace][github-marketplace].
 
 ## Updating an existing service
 
@@ -13,3 +13,4 @@ All pull requests will be reviewed by multiple GitHub staff members before being
 
 [code-of-conduct]: http://todogroup.org/opencodeofconduct/#GitHub%20Services/opensource@github.com
 [webhooks]: https://developer.github.com/webhooks/
+[github-marketplace]: https://github.com/marketplace


### PR DESCRIPTION
Assuming it was replaced with the Marketplace.