### PR TITLE
Strip URL

### DIFF
--- a/lib/service.rb
+++ b/lib/service.rb
@@ -564,6 +564,7 @@ class Service
   # Returns a Faraday::Response instance.
   def http_get(url = nil, params = nil, headers = nil)
     raise_config_error("Invalid scheme") unless permitted_transport?(url)
+    url = url.strip if url
     http.get do |req|
       req.url(url)                if url
       req.params.update(params)   if params
@@ -633,6 +634,7 @@ class Service
   def http_method(method, url = nil, body = nil, headers = nil, params = nil)
     block = Proc.new if block_given?
 
+    url = url.strip if url
     raise_config_error("Invalid scheme") unless permitted_transport?(url)
 
     check_ssl do

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -120,6 +120,33 @@ class ServiceTest < Service::TestCase
     end
   end
 
+  def test_http_get_url_strip
+    stubs = Faraday::Adapter::Test::Stubs.new
+    stubs.get("/") { |env| [200, {}, "ok"] }
+    stubs.get("/   ") { |env| [200, {}, "nope"] }
+
+    service = TestService.new(:push, "data", "payload")
+    service.http :adapter => [:test, stubs]
+
+    service.http_get "https://example.com/   "
+    http_call = service.http_calls[0]
+    assert_equal "https://example.com/", http_call[:request][:url]
+    assert_equal "ok", http_call[:response][:body]
+  end
+
+  def test_http_post_url_strip
+    stubs = Faraday::Adapter::Test::Stubs.new
+    stubs.post("/") { |env| [200, {}, "ok"] }
+    stubs.post("/   ") { |env| [200, {}, "nope"] }
+
+    service = TestService.new(:push, "data", "payload")
+    service.http :adapter => [:test, stubs]
+
+    service.http_post "https://example.com/   "
+    http_call = service.http_calls[0]
+    assert_equal "https://example.com/", http_call[:request][:url]
+    assert_equal "ok", http_call[:response][:body]
+  end
 
   def test_json_encoding
     payload = {'unicodez' => "rtiaü\n\n€ý5:q"}


### PR DESCRIPTION
Removes leading and trailing whitespace from url for those sneaky situations where url's get in here with whitespace.