### PR TITLE
Adding check for 405 status

### DIFF
--- a/lib/services/teamcity.rb
+++ b/lib/services/teamcity.rb
@@ -37,7 +37,7 @@ class Service::TeamCity < Service
       res = perform_post_request(build_type_id, check_for_changes_only, branch: branch)
 
       # Hotfix for older TeamCity versions (older than 2017.1.1) where a GET is needed
-      if res.status == 415
+      if res.status == 415 || res.status == 405
         res = perform_get_request(build_type_id, check_for_changes_only, branch: branch)
       end
 


### PR DESCRIPTION
TeamCity instances older than 2017.1.1 may return a `405` status check if the HTTP method is unsupported. This adds the check for status code `405` as well as `415`.

Please note: GitHub will only accept pull requests to existing services that implement bug fixes or security improvements. We no longer accept feature changes to existing services.
