### PR TITLE
add TeamCity Content-Type; 405 check; end tag

### DIFF
--- a/lib/services/teamcity.rb
+++ b/lib/services/teamcity.rb
@@ -38,7 +38,7 @@ class Service::TeamCity < Service
       res = perform_post_request(build_type_id, check_for_changes_only, branch: branch)
 
       # Hotfix for older TeamCity versions (older than 2017.1.1) where a GET is needed
-      if res.status == 415 | res.status == 405
+      if res.status == 415 || res.status == 405
         res = perform_get_request(build_type_id, check_for_changes_only, branch: branch)
       end
 

--- a/lib/services/teamcity.rb
+++ b/lib/services/teamcity.rb
@@ -29,6 +29,7 @@ class Service::TeamCity < Service
       raise_config_error "No base url: #{base_url.inspect}"
     end
 
+    http.headers['Content-Type'] = 'application/xml'
     http.url_prefix = base_url
     http.basic_auth data['username'].to_s, data['password'].to_s
     build_type_ids = data['build_type_id'].to_s
@@ -37,7 +38,7 @@ class Service::TeamCity < Service
       res = perform_post_request(build_type_id, check_for_changes_only, branch: branch)
 
       # Hotfix for older TeamCity versions (older than 2017.1.1) where a GET is needed
-      if res.status == 415
+      if res.status == 415 | res.status == 405
         res = perform_get_request(build_type_id, check_for_changes_only, branch: branch)
       end
 
@@ -59,7 +60,7 @@ class Service::TeamCity < Service
     if check_for_changes_only
       http_post "httpAuth/app/rest/vcs-root-instances/checkingForChangesQueue?locator=buildType:#{build_type_id}"
     else
-      http_post "httpAuth/app/rest/buildQueue", "<build branchName=\"#{branch}\"><buildType id=\"#{build_type_id}\"></build>"
+      http_post "httpAuth/app/rest/buildQueue", "<build branchName=\"#{branch}\"><buildType id=\"#{build_type_id}\"/></build>"
     end
   end
 

--- a/test/teamcity_test.rb
+++ b/test/teamcity_test.rb
@@ -9,7 +9,7 @@ class TeamCityTest < Service::TestCase
     url = "/abc/httpAuth/app/rest/buildQueue"
     @stubs.post url do |env|
       assert_equal 'teamcity.com', env[:url].host
-      assert_equal '<build branchName=""><buildType id="btid"></build>', env[:body]
+      assert_equal '<build branchName=""><buildType id="btid"/></build>', env[:body]
       assert_equal basic_auth(:u, :p), env[:request_headers]['authorization']
       [200, {}, '']
     end
@@ -51,7 +51,7 @@ class TeamCityTest < Service::TestCase
   def test_push_with_branch_name
     url = "/abc/httpAuth/app/rest/buildQueue"
     @stubs.post url do |env|
-      assert_equal '<build branchName="branch-name"><buildType id="btid"></build>', env[:body]
+      assert_equal '<build branchName="branch-name"><buildType id="btid"/></build>', env[:body]
       [200, {}, '']
     end
 
@@ -67,7 +67,7 @@ class TeamCityTest < Service::TestCase
   def test_push_with_branch_name_incl_slashes
     url = "/abc/httpAuth/app/rest/buildQueue"
     @stubs.post url do |env|
-      assert_equal '<build branchName="branch/name"><buildType id="btid"></build>', env[:body]
+      assert_equal '<build branchName="branch/name"><buildType id="btid"/></build>', env[:body]
       [200, {}, '']
     end
 
@@ -83,7 +83,7 @@ class TeamCityTest < Service::TestCase
   def test_push_with_branch_full_ref
     url = "/abc/httpAuth/app/rest/buildQueue"
     @stubs.post url do |env|
-      assert_equal '<build branchName="refs/heads/branch/name"><buildType id="btid"></build>', env[:body]
+      assert_equal '<build branchName="refs/heads/branch/name"><buildType id="btid"/></build>', env[:body]
       [200, {}, '']
     end
 


### PR DESCRIPTION
Added Content-Type; 405 status check; buildType closing tag

Please note: GitHub will only accept pull requests to existing services that implement bug fixes or security improvements. We no longer accept feature changes to existing services.

### Problem
In addition to [PR#1225](https://github.com/github/github-services/pull/1225), TeamCity instances 9.1 or newer may return a `415` status if the HTTP header is unsupported. Subsequently, if a compliant header is supplied, the TeamCity instance looks for strict request syntax formatting to match.

### Ideas, comments, and workarounds
In testing on a production GitHub Enterprise appliance, adding the `http.headers['Content-Type'] = 'application/xml'` header, and turning the "buildType" element into a valid empty element caused the TeamCity instance to return a successful response.