### PR TITLE
GoCD service integration update

### DIFF
--- a/docs/gocd
+++ b/docs/gocd
@@ -13,11 +13,11 @@ Install Notes
 
 1. Your Go server must be accessible from the internet.
 
-2. "base_url" (mandatory) is the URL to your Go server
-   Example: https://gocd.example.com:8154/go/api/webhooks/github/notify
+2. "base_url" (mandatory) is the domain (and port) of your Go server (don't specify the url part `/go/api/webhooks/github/notify`)
+   Example: https://gocd.example.com:8154
 
 3. "webhook_secret" - to secure the http endpoint you should specify the same
-    value the webhookSecret attribute on the <server/> element has in the file cruise-config.xml.
+    value the webhookSecret attribute on the <server/> element has in the file `cruise-config.xml`.
 
 4. "verify_ssl" is used to enable (recommended) or disable certificate checking when using ssl.
    Disabling this can make the ssl connection insecure.

--- a/docs/gocd
+++ b/docs/gocd
@@ -3,19 +3,21 @@
 The GitHub GoCD service can be used to trigger builds when changes are pushed to the corresponding GitHub repository.
 This is a replacement for the polling method, where the Go server periodically polls the repositories for changes.
 
+This integration completely repeats the webhook API. Read the official instructions on setting up
+webhook push [here](https://api.gocd.org/current/#hosting-your-repository-on-github-or-github-enterprise).
+
+**Note:** Polling must be turned off for the pipeline associated with this material.
+
 Install Notes
 -------------
 
 1. Your Go server must be accessible from the internet.
 
 2. "base_url" (mandatory) is the URL to your Go server
-   Example: https://go.example.com/ or http://go.example.com:8153
+   Example: https://gocd.example.com:8154/go/api/webhooks/github/notify
 
-3. "repository_url" (mandatory) is the URL that is configured in the Materials section of the concerned pipelines.
-   Example: git@github.com:gocd/gocd.git or git://github.com/gocd/gocd
+3. "webhook_secret" - to secure the http endpoint you should specify the same
+    value the webhookSecret attribute on the <server/> element has in the file cruise-config.xml.
 
-4. "username" and "password" - username and password of a Go admin user that can
-   trigger the Materials API endpoint. Can be left empty if the Go server has no authentication configured (not recommended.)
-
-5. "verify_ssl" is used to enable (recommended) or disable certificate checking when using ssl.
+4. "verify_ssl" is used to enable (recommended) or disable certificate checking when using ssl.
    Disabling this can make the ssl connection insecure.

--- a/lib/services/gocd.rb
+++ b/lib/services/gocd.rb
@@ -1,8 +1,8 @@
 class Service::GoCD < Service
-  string   :base_url, :repository_url, :username
-  password :password
+  string   :base_url
+  password :webhook_secret
   boolean :verify_ssl
-  white_list :base_url, :repository_url, :username
+  white_list :base_url
 
   url "http://www.go.cd/"
   logo_url "http://www.go.cd/images/logo-go-home_2014.png"
@@ -16,9 +16,9 @@ class Service::GoCD < Service
     http.url_prefix = base_url
     http.headers['confirm'] = true
 
-    http.basic_auth username, password if username.present? and password.present?
+    # http.basic_auth username, password if username.present? and password.present?
 
-    res = http_post "go/api/material/notify/git", repository_url: repository_url
+    res = http_post "go/api/webhooks/github/notify", repository_url: repository_url
     case res.status
       when 200..299
       when 403, 401, 422 then raise_config_error("Invalid credentials")
@@ -40,16 +40,8 @@ class Service::GoCD < Service
     @base_url ||= data['base_url']
   end
 
-  def repository_url
-    @build_key ||= data['repository_url']
-  end
-
-  def username
-    @username ||= data['username']
-  end
-
-  def password
-    @password ||= data['password']
+  def webhook_secret
+    @webhook_secret ||= data['webhook_secret']
   end
 
   def verify_ssl

--- a/test/gocd_test.rb
+++ b/test/gocd_test.rb
@@ -9,7 +9,7 @@ class GoCDTest < Service::TestCase
   end
 
   def test_push_deleted_branch
-    @stubs.post "go/api/material/notify/git" do
+    @stubs.post "go/api/webhooks/github/notify" do
       assert false, "service should not be called for deleted branches"
     end
 
@@ -47,7 +47,7 @@ class GoCDTest < Service::TestCase
   end
 
   def test_invalid_go_url
-    @stubs.post "go/api/material/notify/git" do
+    @stubs.post "go/api/webhooks/github/notify" do
       [404, {}, ""]
     end
 
@@ -59,7 +59,7 @@ class GoCDTest < Service::TestCase
   end
 
   def test_authorization_passed
-    @stubs.post "go/api/material/notify/git" do |env|
+    @stubs.post "go/api/webhooks/github/notify" do |env|
       assert_equal basic_auth(:admin, :badger), env[:request_headers]['authorization']
       [200, {}, ""]
     end
@@ -70,7 +70,7 @@ class GoCDTest < Service::TestCase
   end
 
   def test_triggers_build
-    @stubs.post "go/api/material/notify/git" do |env|
+    @stubs.post "go/api/webhooks/github/notify" do |env|
       assert_equal "localhost", env[:url].host
       assert_equal 8153, env[:url].port
       [200, {}, ""]
@@ -86,8 +86,7 @@ class GoCDTest < Service::TestCase
     {
       "base_url" => "http://localhost:8153",
       "repository_url" => "git://github.com/gocd/gocd",
-      "username" => "admin",
-      "password" => "badger"
+      "webhook_secret" => "admin"
     }
   end
 
@@ -95,4 +94,3 @@ class GoCDTest < Service::TestCase
     super Service::GoCD, *args
   end
 end
-


### PR DESCRIPTION
Current integration of GoCD with github is obsolete and doesn't work.

I asked GoCD maintainers about it and they pointed me to this github repository and suggested that I fix this: https://github.com/gocd/gocd/issues/4431. I've introduced the appropriate changes to essentially replicate the behaviour of webhook interface.

Unfortunately, I was unable to test this on my local machine. Currently one unit test should surely fail due to invalid `webhookSecret` value.

Please, take a look.