### PR TITLE
Add support for pre-delivery callbacks

### DIFF
--- a/lib/service.rb
+++ b/lib/service.rb
@@ -568,6 +568,11 @@ class Service
   def http_get(url = nil, params = {}, headers = {})
     raise_config_error("Invalid scheme") unless permitted_transport?(url)
     url = url.strip if url
+
+    if pre_delivery_callbacks.any?
+      pre_delivery_callbacks.each { |c| c.call(url, nil, headers, params) }
+    end
+
     http.get do |req|
       req.url(url)                if url
       req.params.update(params)   if params

--- a/lib/service.rb
+++ b/lib/service.rb
@@ -575,8 +575,8 @@ class Service
 
     http.get do |req|
       req.url(url)                if url
-      req.params.update(params)   if params
-      req.headers.update(headers) if headers
+      req.params.update(params)   if params.present?
+      req.headers.update(headers) if headers.present?
       yield req if block_given?
     end
   end

--- a/lib/service.rb
+++ b/lib/service.rb
@@ -484,7 +484,6 @@ class Service
 
   attr_reader :remote_calls
 
-  attr_accessor :needs_public_key_signature, :public_key
   attr_reader :pre_delivery_callbacks
 
   def initialize(event = :push, data = {}, payload = nil)

--- a/lib/service.rb
+++ b/lib/service.rb
@@ -565,7 +565,7 @@ class Service
   #
   # Yields a Faraday::Request instance.
   # Returns a Faraday::Response instance.
-  def http_get(url = nil, params = nil, headers = nil)
+  def http_get(url = nil, params = {}, headers = {})
     raise_config_error("Invalid scheme") unless permitted_transport?(url)
     url = url.strip if url
     http.get do |req|
@@ -861,6 +861,10 @@ class Service
 
   def before_delivery(&block)
     @pre_delivery_callbacks << block
+  end
+
+  def reset_pre_delivery_callbacks!
+    @pre_delivery_callbacks = []
   end
 
   # Raised when an unexpected error occurs during service hook execution.

--- a/lib/service.rb
+++ b/lib/service.rb
@@ -484,6 +484,8 @@ class Service
 
   attr_reader :remote_calls
 
+  attr_accessor :needs_public_key_signature, :public_key
+
   def initialize(event = :push, data = {}, payload = nil)
     helper_name = "#{event.to_s.classify}Helpers"
     if Service.const_defined?(helper_name)

--- a/lib/service/http_helper.rb
+++ b/lib/service/http_helper.rb
@@ -17,7 +17,6 @@ class Service
         body = encode_body(ctype)
 
         set_body_signature(body, secret)
-        set_public_key_signature(body) if needs_public_key_signature
 
         http_post url, body
       end
@@ -76,12 +75,6 @@ class Service
       return if (secret = secret.to_s).empty?
       http.headers['X-Hub-Signature'] =
         'sha1='+OpenSSL::HMAC.hexdigest(HMAC_DIGEST, secret, body)
-    end
-
-    def set_public_key_signature(body)
-      public_key_signature = public_key.sign(message: body, raw: true).signature
-      encoded_signature = Base64.strict_encode64(public_key_signature)
-      http.headers['GITHUB-PUBLIC-KEY-SIGNATURE'] = encoded_signature
     end
 
     def original_body

--- a/lib/service/http_helper.rb
+++ b/lib/service/http_helper.rb
@@ -79,8 +79,8 @@ class Service
     end
 
     def set_public_key_signature(body)
-      public_key_signature  = public_key.sign(message: body).signature
-      encoded_signature     = Base64.strict_encode64(public_key_signature)
+      public_key_signature = public_key.sign(message: body, raw: true).signature
+      encoded_signature = Base64.strict_encode64(public_key_signature)
       http.headers['GITHUB-PUBLIC-KEY-SIGNATURE'] = encoded_signature
     end
 

--- a/lib/service/http_helper.rb
+++ b/lib/service/http_helper.rb
@@ -17,6 +17,7 @@ class Service
         body = encode_body(ctype)
 
         set_body_signature(body, secret)
+        set_public_key_signature(body) if needs_public_key_signature
 
         http_post url, body
       end
@@ -75,6 +76,12 @@ class Service
       return if (secret = secret.to_s).empty?
       http.headers['X-Hub-Signature'] =
         'sha1='+OpenSSL::HMAC.hexdigest(HMAC_DIGEST, secret, body)
+    end
+
+    def set_public_key_signature(body)
+      public_key_signature  = public_key.sign(message: body).signature
+      encoded_signature     = Base64.strict_encode64(public_key_signature)
+      http.headers['GITHUB-PUBLIC-KEY-SIGNATURE'] = encoded_signature
     end
 
     def original_body

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -195,6 +195,28 @@ class ServiceTest < Service::TestCase
     assert_equal 1, @service.http_calls.size
   end
 
+  def test_reset_pre_delivery_callbacks!
+    @service.before_delivery do |url, payload, headers, params|
+      headers['EDITED-IN-BEFORE-DELIVERY'] = true
+      payload.replace("EDITED")
+    end
+
+    @stubs.post '/' do |env|
+      assert_equal 'EDITED', env[:body]
+      assert_equal true, env[:request_headers]['Edited-In-Before-Delivery']
+      [200, {'X-Test' => 'success'}, 'OK']
+    end
+
+    @service.http_post('/', "desrever")
+    @service.reset_pre_delivery_callbacks!
+
+    @stubs.post '/' do |env|
+      refute_equal 'EDITED', env[:body]
+      refute_equal true, env[:request_headers]['Edited-In-Before-Delivery']
+      [200, {'X-Test' => 'success'}, 'OK']
+    end
+  end
+
   def service(*args)
     super TestService, *args
   end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -202,13 +202,13 @@ class ServiceTest < Service::TestCase
       headers['EDITED-IN-BEFORE-DELIVERY-2'] = true
     end
 
-    @stubs.post '/' do |env|
+    @stubs.get '/' do |env|
       assert_equal true, env[:request_headers]['Edited-In-Before-Delivery-1']
       assert_equal true, env[:request_headers]['Edited-In-Before-Delivery-2']
       [200, {'X-Test' => 'success'}, 'OK']
     end
 
-    @service.http_post('/', payload)
+    @service.http_get('/')
 
     @service.http_calls.each do |env|
       assert_equal 200, env[:response][:status]

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -184,7 +184,7 @@ class ServiceTest < Service::TestCase
       [200, {'X-Test' => 'success'}, 'OK']
     end
 
-    @service.http_post('/', "desrever")
+    @service.http_post('/', payload.to_s)
 
     @service.http_calls.each do |env|
       assert_equal 200, env[:response][:status]

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -188,8 +188,6 @@ class ServiceTest < Service::TestCase
 
     @service.http_calls.each do |env|
       assert_equal 200, env[:response][:status]
-      assert_equal 'success', env[:response][:headers]['X-Test']
-      assert_equal 'OK', env[:response][:body]
     end
 
     assert_equal 1, @service.http_calls.size


### PR DESCRIPTION
The original intent of this pull request (c70a09635b276b0be1bbc3b534c7d0b4c0edfbb9...e03332d258976c81598753a726c46b6333ebbd7e) was to add support for public key signing of webhooks. After @mastahyeti's [suggestion](https://github.com/github/github-services/pull/1241#discussion_r179903956) to decouple the current implementation from the key (which would have been injected into the `Service` object upstream), I took a step back and rearchitected the approach of this pull request. 

Its new goal is to add support for "pre-delivery callbacks". Now, upstream of github-services, we'll instantiate a service object and can execute arbitrary code immediately before the delivery of the webhook, without having to modify the code in github-services:

```ruby
service = Service::Web.new

if webhook.needs_signed_header?
  service.before_delivery do |url, payload, headers, params|
    signature = public_key.sign(message: payload)
    headers['GITHUB-PUBLIC-KEY-SIGNATURE'] = signature
  end
end
```