### PR TITLE
Remove documentation for depending.in

### DIFF
--- a/docs/depending
+++ b/docs/depending
@@ -1,7 +1,0 @@
-Install Notes
--------------
-
-1. Create an account at http://depending.in
-2. Enter your Token (see instructions below)
-
-To get your Token: Log into your Depending account, click the carret icon at the top-right, then click the setting tab.


### PR DESCRIPTION
In #1240, we removed support for the depending.in service, but forgot to remove the corresponding documentation for it, which caused a linter failure upstream of this project. This pull request removes the corresponding documentation.

/cc @dgw & @gjtorikian as an FYI