### PR TITLE
Add some hard dates around deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 GitHub Services
 ===============
 
+**NOTE:** GitHub Services have been [marked for deprecation](https://developer.github.com/changes/2018-04-25-github-services-deprecation/). Functionality will be removed from GitHub.com on October 1, 2018.
+
 This repository contains code to integrate GitHub.com with third party services.
 
 See the [Contributing Guidelines](https://github.com/github/github-services/blob/master/.github/CONTRIBUTING.md) for instructions on contributing a service.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 GitHub Services
 ===============
 
-**NOTE:** GitHub Services have been [marked for deprecation](https://developer.github.com/changes/2018-04-25-github-services-deprecation/). Functionality will be removed from GitHub.com on October 1, 2018.
+**NOTE:** GitHub Services have been [marked for deprecation](https://developer.github.com/changes/2018-04-25-github-services-deprecation/). Functionality will be removed from GitHub.com on January 31st, 2019.
 
 This repository contains code to integrate GitHub.com with third party services.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 GitHub Services
 ===============
 
-**NOTE:** GitHub Services have been [marked for deprecation](https://developer.github.com/changes/2018-04-25-github-services-deprecation/). Functionality will be removed from GitHub.com on January 31st, 2019.
+**NOTE:** GitHub Services has been [marked for deprecation](https://developer.github.com/changes/2018-04-25-github-services-deprecation/). Functionality will be removed from GitHub.com on January 31st, 2019.
 
 This repository contains code to integrate GitHub.com with third party services.
 

--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -191,12 +191,12 @@ class Service::Email < Service
       end
 
       body << compare_text unless single_commit?
-
+      binding
       body << <<-NOTE
 
       **NOTE:** GitHub Services have been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/).
 
-      Functionality will be removed from GitHub.com on October 1, 2018.
+      Functionality will be removed from GitHub.com on January 31st, 2019.
       NOTE
     end
 

--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -192,7 +192,12 @@ class Service::Email < Service
 
       body << compare_text unless single_commit?
 
-      body
+      body << <<-NOTE
+
+      **NOTE:** GitHub Services have been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/).
+
+      Functionality will be removed from GitHub.com on October 1, 2018.
+      NOTE
     end
 
     # Public

--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -194,7 +194,7 @@ class Service::Email < Service
 
       body << <<-NOTE
 
-      **NOTE:** This service been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/).
+      **NOTE:** This service been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/
 
       Functionality will be removed from GitHub.com on January 31st, 2019.
       NOTE

--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -191,10 +191,10 @@ class Service::Email < Service
       end
 
       body << compare_text unless single_commit?
-      binding
+
       body << <<-NOTE
 
-      **NOTE:** GitHub Services have been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/).
+      **NOTE:** This service been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/).
 
       Functionality will be removed from GitHub.com on January 31st, 2019.
       NOTE


### PR DESCRIPTION
We've [now announced](https://developer.github.com/changes/2018-04-25-github-services-deprecation/) the official deprecation of GitHub Services. This PR updates some of the documentation to make clear that this project will be archived.

cc @github/ecosystem-api @github/services-deprecation @stevecat 
Should close https://github.com/github/ecosystem-api/issues/1141.