### PR TITLE
Send deprecation notice with IRC and XMPP messages

### DIFF
--- a/lib/service.rb
+++ b/lib/service.rb
@@ -2,6 +2,12 @@
 # type, the configuration data, and the payload for the current call.
 class Service
   UTF8 = "UTF-8".freeze
+  DEPRECATION_NOTE = [
+    "**NOTE:** This service been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/",
+    "",
+    "Functionality will be removed from GitHub.com on January 31st, 2019.",
+    ""
+  ].join("\n")
   class Contributor < Struct.new(:value)
     def self.contributor_types
       @contributor_types ||= []

--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -192,12 +192,7 @@ class Service::Email < Service
 
       body << compare_text unless single_commit?
 
-      body << <<-NOTE
-
-      **NOTE:** This service been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/
-
-      Functionality will be removed from GitHub.com on January 31st, 2019.
-      NOTE
+      body << Service::DEPRECATION_NOTE
     end
 
     # Public

--- a/lib/services/irc.rb
+++ b/lib/services/irc.rb
@@ -43,6 +43,7 @@ class Service::IRC < Service
 
   def send_messages(messages)
     messages = Array(messages)
+    messages.push(*Service::DEPRECATION_NOTE.split("\n"))
 
     if config_boolean_true?('no_colors')
       messages.each{|message|

--- a/lib/services/xmpp_im.rb
+++ b/lib/services/xmpp_im.rb
@@ -15,9 +15,11 @@ class Service::XmppIm < XmppHelper
   default_events :push, :commit_comment, :issue_comment,
     :issues, :pull_request, :pull_request_review_comment,
     :gollum
- 
+
   def send_messages(messages)
     messages = Array(messages)
+    messages << Service::DEPRECATION_NOTE
+
     setup_connection()
     @receivers.each do |receiver|
       messages.each do |message|

--- a/lib/services/xmpp_muc.rb
+++ b/lib/services/xmpp_muc.rb
@@ -1,10 +1,10 @@
 require_relative 'xmpp_base'
 
 class Service::XmppMuc < XmppHelper
-    
+
   self.title = 'XMPP MUC'
   self.hook_name = 'xmpp_muc'
-    
+
   string :JID, :room, :server, :nickname, :host, :port
   password :password, :room_password
   boolean :notify_fork, :notify_wiki, :notify_comments,
@@ -15,9 +15,11 @@ class Service::XmppMuc < XmppHelper
   default_events :push, :commit_comment, :issue_comment,
     :issues, :pull_request, :pull_request_review_comment,
     :gollum
-    
+
   def send_messages(messages)
     messages = Array(messages)
+    messages << Service::DEPRECATION_NOTE
+
     setup_muc_connection()
     messages.each do |message|
         @muc.send ::Jabber::Message::new(::Jabber::JID.new(@data['muc_room']), message)
@@ -26,7 +28,7 @@ class Service::XmppMuc < XmppHelper
     ensure
       @client.close if @client
   end
-    
+
   def setup_muc_connection
       if (@muc.nil?)
         begin
@@ -48,11 +50,11 @@ class Service::XmppMuc < XmppHelper
       end
       @muc
   end
-    
+
   def set_muc_connection(muc)
       @muc = muc
   end
-          
+
   def check_config(data)
     raise_config_error 'JID is required' if data['JID'].to_s.empty?
     raise_config_error 'Password is required' if data['password'].to_s.empty?

--- a/test/irc_test.rb
+++ b/test/irc_test.rb
@@ -30,6 +30,9 @@ class IRCTest < Service::TestCase
       /PRIVMSG #r.*grit/,
       /PRIVMSG #r.*grit/,
       /PRIVMSG #r.*grit/,
+      /PRIVMSG #r.*/,
+      /PRIVMSG #r.*/,
+      /PRIVMSG #r.*/,
       "PART #r",
       "QUIT"
     ]
@@ -60,6 +63,9 @@ class IRCTest < Service::TestCase
       /PRIVMSG #r.*grit/,
       /PRIVMSG #r.*grit/,
       /PRIVMSG #r.*grit/,
+      /PRIVMSG #r.*/,
+      /PRIVMSG #r.*/,
+      /PRIVMSG #r.*/,
       "PART #r",
       "QUIT"
     ]
@@ -91,6 +97,9 @@ class IRCTest < Service::TestCase
       /PRIVMSG #r.*grit/,
       /PRIVMSG #r.*grit/,
       /PRIVMSG #r.*grit/,
+      /PRIVMSG #r.*/,
+      /PRIVMSG #r.*/,
+      /PRIVMSG #r.*/,
       "PART #r",
       "QUIT"
     ]
@@ -128,6 +137,9 @@ class IRCTest < Service::TestCase
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_match /PRIVMSG #r.*grit/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
     assert_equal "QUIT", msgs.shift.strip
     assert_nil msgs.shift
@@ -145,6 +157,9 @@ class IRCTest < Service::TestCase
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_match /PRIVMSG #r.*grit/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
     assert_equal "QUIT", msgs.shift.strip
     assert_nil msgs.shift
@@ -162,6 +177,9 @@ class IRCTest < Service::TestCase
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_match /PRIVMSG #r.*grit/, msgs.shift
     assert_match /PRIVMSG #r.*grit/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
     assert_equal "QUIT", msgs.shift.strip
     assert_nil msgs.shift
@@ -176,6 +194,9 @@ class IRCTest < Service::TestCase
     assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
     assert_equal "QUIT", msgs.shift.strip
     assert_nil msgs.shift
@@ -190,6 +211,9 @@ class IRCTest < Service::TestCase
     assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
     assert_equal "QUIT", msgs.shift.strip
     assert_nil msgs.shift
@@ -204,6 +228,9 @@ class IRCTest < Service::TestCase
     assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
     assert_equal "QUIT", msgs.shift.strip
     assert_nil msgs.shift
@@ -218,6 +245,9 @@ class IRCTest < Service::TestCase
     assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
     assert_equal "QUIT", msgs.shift.strip
     assert_nil msgs.shift
@@ -232,6 +262,9 @@ class IRCTest < Service::TestCase
     assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*grit.*pull request #5 /, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
     assert_equal "QUIT", msgs.shift.strip
     assert_nil msgs.shift
@@ -246,6 +279,9 @@ class IRCTest < Service::TestCase
     assert_match /USER n . . :[^-]+- \w+(\/\w+)?/, msgs.shift
     assert_equal "JOIN #r", msgs.shift.strip
     assert_match /PRIVMSG #r.*\[grit\] defunkt created wiki page Foo/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
+    assert_match /PRIVMSG #r.*/, msgs.shift
     assert_equal "PART #r", msgs.shift.strip
     assert_equal "QUIT", msgs.shift.strip
     assert_nil msgs.shift

--- a/test/xmpp_im_test.rb
+++ b/test/xmpp_im_test.rb
@@ -198,7 +198,7 @@ class XmppImTest < Service::TestCase
       message = ''
       service(:push, config, payload).receive_event
       assert_equal(
-          8,
+          10,
           @mock.get_messages().length,
           'Expected 8 messages'
       )
@@ -233,25 +233,25 @@ class XmppImTest < Service::TestCase
   def test_sends_messages_to_expected_jids
     service(:commit_comment, @config, commit_comment_payload).receive_event
       assert_equal(
-          2,
+          4,
           @mock.get_messages().length,
-          'Expected 2 messages'
+          'Expected 4 messages'
       )
       assert_equal(
           ::Jabber::JID.new('full@server/resource'),
-          @mock.get_messages()[1].to
+          @mock.get_messages()[3].to
       )
       assert_equal(
           ::Jabber::JID.new('bare@server'),
           @mock.get_messages()[0].to
       )
   end
-    
+
   def test_generates_expected_commit_comment_message
       message = '[grit] @defunkt commented on commit 441e568: this... https://github.com/mojombo/magik/commit/441e5686a726b79bcdace639e2591a60718c9719#commitcomment-3332777'
       service(:commit_comment, @config, commit_comment_payload).receive_event
       assert_equal(
-          2,
+          4,
           @mock.get_messages().length,
           'Expected 2 messages'
       )
@@ -261,18 +261,18 @@ class XmppImTest < Service::TestCase
           'Expected commit comment message not received'
       )
   end
-    
-  def test_generates_error_if_commit_comment_message_cant_be_generated 
+
+  def test_generates_error_if_commit_comment_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       service(:commit_comment, @config, {}).receive_event
     end
   end
-    
+
   def test_generates_expected_issue_comment_message
       message = '[grit] @defunkt commented on issue #5: this... '
       service(:issue_comment, @config, issue_comment_payload).receive_event
       assert_equal(
-          2,
+          4,
           @mock.get_messages().length,
           'Expected 2 messages'
       )
@@ -283,19 +283,19 @@ class XmppImTest < Service::TestCase
       )
   end
 
-  def test_generates_error_if_issue_comment_message_cant_be_generated 
+  def test_generates_error_if_issue_comment_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       service(:issue_comment, @config, {}).receive_event
     end
   end
-    
+
   def test_generates_expected_issues_message
       message = '[grit] @defunkt opened issue #5: booya '
       service(:issues, @config, issues_payload).receive_event
       assert_equal(
-          2,
+          4,
           @mock.get_messages().length,
-          'Expected 2 messages'
+          'Expected 4 messages'
       )
       assert_equal(
           message,
@@ -304,17 +304,17 @@ class XmppImTest < Service::TestCase
       )
   end
 
-  def test_generates_error_if_issues_message_cant_be_generated 
+  def test_generates_error_if_issues_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       service(:issues, @config, {}).receive_event
     end
   end
-    
+
   def test_generates_expected_pull_request_message
       message = '[grit] @defunkt opened pull request #5: booya (master...feature) https://github.com/mojombo/magik/pulls/5'
       service(:pull_request, @config, pull_request_payload).receive_event
       assert_equal(
-          2,
+          4,
           @mock.get_messages().length,
           'Expected 2 messages'
       )
@@ -325,19 +325,19 @@ class XmppImTest < Service::TestCase
       )
   end
 
-  def test_generates_error_if_pull_request_message_cant_be_generated 
+  def test_generates_error_if_pull_request_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       payload = pull_request_payload
       payload['pull_request']['base'] = {}
       service(:pull_request, @config, payload).receive_event
     end
   end
-    
+
   def test_generates_expected_pull_request_review_comment_message
       message = '[grit] @defunkt commented on pull request #5 03af7b9: very... https://github.com/mojombo/magik/pull/5#discussion_r18785396'
       service(:pull_request_review_comment, @config, pull_request_review_comment_payload).receive_event
       assert_equal(
-          2,
+          4,
           @mock.get_messages().length,
           'Expected 2 messages'
       )
@@ -348,17 +348,17 @@ class XmppImTest < Service::TestCase
       )
   end
 
-  def test_generates_error_if_pull_request_review_comment_message_cant_be_generated 
+  def test_generates_error_if_pull_request_review_comment_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       service(:pull_request_review_comment, @config, {}).receive_event
     end
   end
-    
+
   def test_generates_expected_gollum_message
       message = '[grit] @defunkt modified 1 page https://github.com/mojombo/magik/wiki/Foo'
       service(:gollum, @config, gollum_payload).receive_event
       assert_equal(
-          4,
+          6,
           @mock.get_messages().length,
           'Expected 4 messages'
       )

--- a/test/xmpp_muc_test.rb
+++ b/test/xmpp_muc_test.rb
@@ -5,33 +5,33 @@ class XmppMucTest < Service::TestCase
       @messages = [] if @messages.nil?
       @messages.push message
     end
-      
+
     def get_messages
         @messages
     end
-      
+
     def connect(host, port)
       @host = host
       @port = port
     end
-      
+
     def get_host
       @host
     end
-      
+
     def get_port
       @port
     end
-      
+
     def exit
-        
+
     end
 
   end
 
   def setup
     @stubs = Faraday::Adapter::Test::Stubs.new
-      
+
     @config = {
       'JID' => 'me@example.com',
       'password' => 'password',
@@ -48,7 +48,7 @@ class XmppMucTest < Service::TestCase
     }
     @mock = MockXmpp4r.new()
   end
-    
+
   def service(*args)
     xmppMuc = super Service::XmppMuc, *args
     xmppMuc.set_muc_connection @mock
@@ -86,7 +86,7 @@ class XmppMucTest < Service::TestCase
       service(config, payload).receive_event
     end
   end
-    
+
   def test_errors_on_bad_port
     assert_raises(Service::ConfigurationError, 'XMPP port must be numeric') do
       config = @config
@@ -94,8 +94,8 @@ class XmppMucTest < Service::TestCase
       service(config, payload).receive_event
     end
   end
-    
-    
+
+
   def sets_custom_port
     config = @config
     port = '1234'
@@ -103,7 +103,7 @@ class XmppMucTest < Service::TestCase
     service(config, payload).receive_event
     assert_equal(Integer(port), @mock.get_port)
   end
-    
+
   def sets_custom_host
     config = @config
     host = 'github.com'
@@ -111,19 +111,19 @@ class XmppMucTest < Service::TestCase
     service(config, payload).receive_event
     assert_equal(host, @mock.get_host)
   end
-    
+
   def uses_default_host
     config = @config
     service(config, payload).receive_event
-    assert_true(@mock.get_host.nil?) 
+    assert_true(@mock.get_host.nil?)
   end
-    
+
   def uses_default_port
     config = @config
     service(config, payload).receive_event
     assert_equal(5222, @mock.get_port)
   end
-    
+
   def test_returns_false_if_not_on_filtered_branch
     config = @config
     config['filter_branch'] = 'development'
@@ -131,9 +131,9 @@ class XmppMucTest < Service::TestCase
       false,
       service(config, payload).receive_event,
       'Should have filtered by branch'
-    )  
+    )
   end
-    
+
   def test_returns_true_if_part_matched_filtered_branch
     config = @config
     config['filter_branch'] = 'ast'
@@ -141,9 +141,9 @@ class XmppMucTest < Service::TestCase
       true,
       service(config, payload).receive_event,
       'Should not have filtered this branch'
-    )  
+    )
   end
-    
+
   def test_returns_false_if_fork_event_and_not_notifiying
     config = @config
     config['notify_fork'] = '0'
@@ -151,9 +151,9 @@ class XmppMucTest < Service::TestCase
       false,
       service(:fork, config, payload).receive_event,
       'Should not reported fork event'
-    ) 
+    )
   end
-    
+
   def test_returns_false_if_watch_event_and_not_notifiying
     config = @config
     config['notify_watch'] = '0'
@@ -161,9 +161,9 @@ class XmppMucTest < Service::TestCase
       false,
       service(:watch, config, payload).receive_event,
       'Should not reported watch event'
-    ) 
-  end  
-    
+    )
+  end
+
   def test_returns_false_if_comment_event_and_not_notifiying
     config = @config
     config['notify_comments'] = '0'
@@ -173,7 +173,7 @@ class XmppMucTest < Service::TestCase
       'Should not reported comment event'
     )
   end
-    
+
   def test_returns_false_if_wiki_event_and_not_notifiying
     config = @config
     config['notify_wiki'] = '0'
@@ -183,7 +183,7 @@ class XmppMucTest < Service::TestCase
       'Should not reported wiki event'
     )
   end
-    
+
   def test_returns_false_if_issue_event_and_not_notifiying
     config = @config
     config['notify_issue'] = '0'
@@ -193,7 +193,7 @@ class XmppMucTest < Service::TestCase
       'Should not reported issues event'
     )
   end
-    
+
   def test_returns_false_if_pull_event_and_not_notifiying
     config = @config
     config['notify_pull'] = '0'
@@ -209,9 +209,9 @@ class XmppMucTest < Service::TestCase
       message = ''
       service(:push, config, payload).receive_event
       assert_equal(
-          4,
+          5,
           @mock.get_messages().length,
-          'Expected 4 messages'
+          'Expected 5 messages'
       )
       assert_equal(
           "[grit] @rtomayko pushed 3 new commits to master: http://github.com/mojombo/grit/compare/4c8124f...a47fd41",
@@ -235,19 +235,19 @@ class XmppMucTest < Service::TestCase
       )
   end
 
-  def test_generates_error_if_push_message_cant_be_generated 
+  def test_generates_error_if_push_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       service(:commit_comment, @config, {}).receive_event
     end
   end
-    
+
   def test_generates_expected_commit_comment_message
       message = '[grit] @defunkt commented on commit 441e568: this... https://github.com/mojombo/magik/commit/441e5686a726b79bcdace639e2591a60718c9719#commitcomment-3332777'
       service(:commit_comment, @config, commit_comment_payload).receive_event
       assert_equal(
-          1,
+          2,
           @mock.get_messages().length,
-          'Expected 1 message'
+          'Expected 2 messages'
       )
       assert_equal(
           message,
@@ -255,20 +255,20 @@ class XmppMucTest < Service::TestCase
           'Expected commit comment message not received'
       )
   end
-    
-  def test_generates_error_if_commit_comment_message_cant_be_generated 
+
+  def test_generates_error_if_commit_comment_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       service(:commit_comment, @config, {}).receive_event
     end
   end
-    
+
   def test_generates_expected_issue_comment_message
       message = '[grit] @defunkt commented on issue #5: this... '
       service(:issue_comment, @config, issue_comment_payload).receive_event
       assert_equal(
-          1,
+          2,
           @mock.get_messages().length,
-          'Expected 1 message'
+          'Expected 2 messages'
       )
       assert_equal(
           message,
@@ -277,19 +277,19 @@ class XmppMucTest < Service::TestCase
       )
   end
 
-  def test_generates_error_if_issue_comment_message_cant_be_generated 
+  def test_generates_error_if_issue_comment_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       service(:issue_comment, @config, {}).receive_event
     end
   end
-    
+
   def test_generates_expected_issues_message
       message = '[grit] @defunkt opened issue #5: booya '
       service(:issues, @config, issues_payload).receive_event
       assert_equal(
-          1,
+          2,
           @mock.get_messages().length,
-          'Expected 1 message'
+          'Expected 2 messages'
       )
       assert_equal(
           message,
@@ -298,19 +298,19 @@ class XmppMucTest < Service::TestCase
       )
   end
 
-  def test_generates_error_if_issues_message_cant_be_generated 
+  def test_generates_error_if_issues_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       service(:issues, @config, {}).receive_event
     end
   end
-    
+
   def test_generates_expected_pull_request_message
       message = '[grit] @defunkt opened pull request #5: booya (master...feature) https://github.com/mojombo/magik/pulls/5'
       service(:pull_request, @config, pull_request_payload).receive_event
       assert_equal(
-          1,
+          2,
           @mock.get_messages().length,
-          'Expected 1 message'
+          'Expected 2 messages'
       )
       assert_equal(
           message,
@@ -319,21 +319,21 @@ class XmppMucTest < Service::TestCase
       )
   end
 
-  def test_generates_error_if_pull_request_message_cant_be_generated 
+  def test_generates_error_if_pull_request_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       payload = pull_request_payload
       payload['pull_request']['base'] = {}
       service(:pull_request, @config, payload).receive_event
     end
   end
-    
+
   def test_generates_expected_pull_request_review_comment_message
       message = '[grit] @defunkt commented on pull request #5 03af7b9: very... https://github.com/mojombo/magik/pull/5#discussion_r18785396'
       service(:pull_request_review_comment, @config, pull_request_review_comment_payload).receive_event
       assert_equal(
-          1,
+          2,
           @mock.get_messages().length,
-          'Expected 1 message'
+          'Expected 2 messages'
       )
       assert_equal(
           message,
@@ -342,19 +342,19 @@ class XmppMucTest < Service::TestCase
       )
   end
 
-  def test_generates_error_if_pull_request_review_comment_message_cant_be_generated 
+  def test_generates_error_if_pull_request_review_comment_message_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       service(:pull_request_review_comment, @config, {}).receive_event
     end
   end
-    
+
   def test_generates_expected_gollum_message
       message = '[grit] @defunkt modified 1 page https://github.com/mojombo/magik/wiki/Foo'
       service(:gollum, @config, gollum_payload).receive_event
       assert_equal(
-          2,
+          3,
           @mock.get_messages().length,
-          'Expected 2 message'
+          'Expected 3 messages'
       )
       assert_equal(
           message,
@@ -368,10 +368,10 @@ class XmppMucTest < Service::TestCase
       )
   end
 
-  def test_generates_error_if_gollum_cant_be_generated 
+  def test_generates_error_if_gollum_cant_be_generated
     assert_raises(Service::ConfigurationError, /Unable to build message/) do
       service(:gollum, @config, {}).receive_event
     end
   end
- 
+
 end


### PR DESCRIPTION
This PR sends our deprecation notice with IRC and XMPP messages

## To do

- [x] Abstract out deprecation notice
- [x] Send with XmppIm messages
- [x] Update XmppIm tests
- [x] Send with XmppMuc messages
- [x] Update XmppMuc tests
- [x] Send with IRC messages
- [x] Update IRC tests