### PR TITLE
Fix grammar in mailer deprecation note

### DIFF
--- a/lib/services/email.rb
+++ b/lib/services/email.rb
@@ -194,7 +194,7 @@ class Service::Email < Service
 
       body << <<-NOTE
 
-      **NOTE:** This service been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/
+      **NOTE:** This service has been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/
 
       Functionality will be removed from GitHub.com on January 31st, 2019.
       NOTE


### PR DESCRIPTION
I just got a notification on a throwaway repository where the email service is enabled which includes:

> **NOTE:** This service been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/

Since this mail is going out on every push, it would be nice to fix the grammar so that the note reads:

> **NOTE:** This service has been marked for deprecation: https://developer.github.com/changes/2018-04-25-github-services-deprecation/
