### PR TITLE
update readme with deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
+
+🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
+
+**_GitHub Services has been deprecated_. No more contributions will be accepted. Please see our [blog post](https://developer.github.com/changes/2018-04-25-github-services-deprecation/) for more information.**
+
+🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
+
 GitHub Services
 ===============
-
-**NOTE:** GitHub Services has been [marked for deprecation](https://developer.github.com/changes/2018-04-25-github-services-deprecation/). Functionality will be removed from GitHub.com on January 31st, 2019.
 
 This repository contains code to integrate GitHub.com with third party services.
 


### PR DESCRIPTION
## Context

The last day for GitHub Services is 1/31/19. This updates the README to contain a clear warning that the repo is deprecated. We should merge this before archiving the repo.

👉[rendered version here](https://github.com/github/github-services/blob/22f68bab1618b81a7ae45fab93e6dd32e998aeef/README.md)👈

## This Change

- update README with clear warning about deprecation